### PR TITLE
Update GitHub Actions CI config

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, macos-10.15]
         node-version: [12.x, 14.x]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-10.15]
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
This patch updates the GitHub Actions CI config:

- Add 'macos-10.15' as one of the platforms in the platform matrix.
- Removes Node.js runtime version `12.x`, using only `14.x` (for both `ubuntu-latest` and `macOS-10.15`).