### PR TITLE
Improve contrast of content page banner title and subtitle text

### DIFF
--- a/src/components/shared/ContentPageBanner.css
+++ b/src/components/shared/ContentPageBanner.css
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 06, 2020
- * Updated  : Aug 22, 2020
+ * Updated  : Aug 08, 2021
  */
 
 div.ContentPageBannerContainer {

--- a/src/components/shared/ContentPageBanner.css
+++ b/src/components/shared/ContentPageBanner.css
@@ -31,6 +31,7 @@ p.ContentPageBannerTitle {
   font-size: 80px;
   font-weight: 800;
   margin: 0 auto;
+  text-shadow: 2px 2px 5px #000;
 }
 
 hr.ContentPageBannerTitleLineBreak {
@@ -48,6 +49,7 @@ p.ContentPageBannerSubtitle {
   font-weight: 520;
   line-height: 1.6;
   color: white;
+  text-shadow: 1px 1px 3px #000;
 }
 
 @media (max-width: 1280px) {


### PR DESCRIPTION
Currently, the content page banner title and subtitle texts have very poor contrast with the banner background image, making them hard to read, especially on pages where the background image is bright.

This patch fixes the issue by introducing text shadow to both the banner title and subtitle texts, making them much more standout from the background image, therefore much easier to read.

----

**Comparison:**

Before::

<img width="597" alt="PR221_Before" src="https://user-images.githubusercontent.com/554685/128640121-df6393df-fa8f-4f7a-90ea-ded2dae854b7.png">

After:

<img width="597" alt="PR221_After" src="https://user-images.githubusercontent.com/554685/128640125-e4c8e78e-c235-407c-b67a-fdce0ed22905.png">
