### PR TITLE
Minor refinement in homepage explore gateway layout

### DIFF
--- a/src/__tests__/__snapshots__/App.test.js.snap
+++ b/src/__tests__/__snapshots__/App.test.js.snap
@@ -51,7 +51,7 @@ exports[`App component snapshot 1`] = `
     id="Explore"
   >
     <div
-      className="ExploreGatewayIntro"
+      className="ExploreGatewayIntro ExploreGatewayBackground"
       data-testid="ExploreGatewayIntroTestId"
     >
       <div
@@ -95,66 +95,11 @@ exports[`App component snapshot 1`] = `
           </div>
         </div>
       </div>
-      <div
-        className="ExploreGatewayIntroCenterGrid VerticalCushionPadding"
-        id="ExploreGatewayMenu"
-      >
-        <div
-          className="FluidSingleRowGridOuterContainer"
-          style={
-            Object {
-              "justifyContent": "center",
-            }
-          }
-        >
-          <div
-            className="ExploreGatewayIntroCenterGridLhsColumnStyle"
-          >
-            <p
-              className="CCFMissionStatementQuote"
-            >
-              “CCF is Changing the World to Save the Cheetah” - Dr. Laurie Marker
-            </p>
-          </div>
-          <div
-            className="ExploreGatewayIntroCenterGridRhsColumnStyle"
-          >
-            <div
-              className="ui inverted segment"
-            >
-              <p
-                className="JoinTheRace"
-              >
-                Join the race to 
-                <a
-                  href="https://twitter.com/search?q=%23SaveTheCheetah"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  <span
-                    className="SafeTheCheetah"
-                  >
-                    #SafeTheCheetah
-                  </span>
-                </a>
-              </p>
-              <p>
-                Cheetahs can't win without us.
-              </p>
-              <a
-                className="ui basic inverted button"
-                href="https://cheetah.org/get-involved/ways-to-give/"
-                onClick={[Function]}
-                role="button"
-              >
-                Get Involved
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
-    <nav>
+    <nav
+      className="ExploreGatewayGrid"
+      id="ExploreGatewayMenu"
+    >
       <div
         className="ui container stackable center aligned four column grid"
         data-testid="ExploreGatewayGridTestId"
@@ -269,7 +214,63 @@ exports[`App component snapshot 1`] = `
         </div>
       </div>
     </nav>
-    <br />
+    <div
+      className="ExploreGatewayFooter ExploreGatewayBackground VerticalCushionPadding"
+    >
+      <div
+        className="FluidSingleRowGridOuterContainer"
+        style={
+          Object {
+            "justifyContent": "center",
+          }
+        }
+      >
+        <div
+          className="ExploreGatewayIntroCenterGridLhsColumnStyle"
+        >
+          <p
+            className="CCFMissionStatementQuote"
+          >
+            “CCF is Changing the World to Save the Cheetah” - Dr. Laurie Marker
+          </p>
+        </div>
+        <div
+          className="ExploreGatewayIntroCenterGridRhsColumnStyle"
+        >
+          <div
+            className="ui inverted segment"
+          >
+            <p
+              className="JoinTheRace"
+            >
+              Join the race to 
+              <a
+                href="https://twitter.com/search?q=%23SaveTheCheetah"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <span
+                  className="SafeTheCheetah"
+                >
+                  #SafeTheCheetah
+                </span>
+              </a>
+            </p>
+            <p>
+              Cheetahs can't win without us.
+            </p>
+            <a
+              className="ui basic inverted button"
+              href="https://cheetah.org/get-involved/ways-to-give/"
+              onClick={[Function]}
+              role="button"
+            >
+              Get Involved
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <footer>
     <div

--- a/src/components/homepage/ExploreGateway.js
+++ b/src/components/homepage/ExploreGateway.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 02, 2020
- * Updated  : Jul 28, 2020
+ * Updated  : Aug 08, 2021
  */
 
 import React from 'react'
@@ -13,13 +13,14 @@ import "semantic-ui-css/semantic.min.css"
 
 import ExploreGatewayIntro from './ExploreGatewayIntro'
 import ExploreGatewayGrid from './ExploreGatewayGrid'
+import ExploreGatewayFooter from './ExploreGatewayFooter'
 
 export default function ExploreGateway() {
   return (
     <div id="Explore" data-testid="ExploreGatewayComponentTestId">
       <ExploreGatewayIntro/>
       <ExploreGatewayGrid/>
-      <br/>
+      <ExploreGatewayFooter/>
     </div>
   );
 }

--- a/src/components/homepage/ExploreGatewayFooter.css
+++ b/src/components/homepage/ExploreGatewayFooter.css
@@ -1,0 +1,12 @@
+/**
+ * ExploreGatewayFooter.css
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Aug 08, 2021
+ * Updated  : Aug 08, 2021
+ */
+
+div.ExploreGatewayFooter {
+    padding: 35px 0px 35px 0px;
+}

--- a/src/components/homepage/ExploreGatewayFooter.js
+++ b/src/components/homepage/ExploreGatewayFooter.js
@@ -1,0 +1,56 @@
+/**
+ * ExploreGatewayFooter.js
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Aug 08, 2021
+ * Updated  : Aug 08, 2021
+ */
+
+import React from 'react'
+
+import {
+    Button,
+    Segment
+} from 'semantic-ui-react'
+
+import FluidSingleRowGrid from '../shared/FluidSingleRowGrid'
+
+import 'semantic-ui-css/semantic.min.css'
+
+import '../shared/GlobalStyles.css'
+
+import '../shared/ContentPageSharedStyles.css'
+
+import './ExploreGatewaySharedStyles.css'
+
+import './ExploreGatewayFooter.css'
+
+export default function ExploreGatewayFooter() {
+    return (
+        <div className="ExploreGatewayFooter ExploreGatewayBackground VerticalCushionPadding">
+            <FluidSingleRowGrid justifyContent="center">
+                <div className="ExploreGatewayIntroCenterGridLhsColumnStyle">
+                    <p className="CCFMissionStatementQuote">
+                    “CCF is Changing the World to Save the Cheetah” - Dr. Laurie Marker
+                    </p>
+                </div>
+                <div className="ExploreGatewayIntroCenterGridRhsColumnStyle">
+                    <Segment inverted>
+                    <p className="JoinTheRace">
+                        Join the race to <a href="https://twitter.com/search?q=%23SaveTheCheetah" target="_blank" rel="noopener noreferrer">
+                        <span className="SafeTheCheetah">
+                            #SafeTheCheetah
+                        </span>
+                        </a>
+                    </p>
+                    <p>Cheetahs can't win without us.</p>
+                    <Button basic inverted href="https://cheetah.org/get-involved/ways-to-give/">
+                        Get Involved
+                    </Button>
+                    </Segment>
+                </div>
+            </FluidSingleRowGrid>
+        </div>
+    );
+}

--- a/src/components/homepage/ExploreGatewayGrid.css
+++ b/src/components/homepage/ExploreGatewayGrid.css
@@ -1,0 +1,12 @@
+/**
+ * ExploreGatewayGrid.css
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Aug 08, 2021
+ * Updated  : Aug 08, 2021
+ */
+
+.ExploreGatewayGrid {
+    margin: 40px 0px 40px 0px;
+}

--- a/src/components/homepage/ExploreGatewayGrid.js
+++ b/src/components/homepage/ExploreGatewayGrid.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 02, 2020
- * Updated  : Aug 18, 2020
+ * Updated  : Aug 08, 2021
  */
 
 import React from 'react'
@@ -12,6 +12,8 @@ import React from 'react'
 import { Grid } from 'semantic-ui-react'
 
 import 'semantic-ui-css/semantic.min.css'
+
+import './ExploreGatewayGrid.css'
 
 import ExploreGatewayGridItem from './ExploreGatewayGridItem'
 
@@ -22,7 +24,7 @@ import explore_gateway_grid_item_img_04 from './assets/explore_gateway_grid_item
 
 export default function ExploreGatewayGrid() {
   return (
-    <nav>
+    <nav id="ExploreGatewayMenu" className="ExploreGatewayGrid">
       <Grid container stackable textAlign="center" columns={4} data-testid="ExploreGatewayGridTestId">
         <ExploreGatewayGridItem image={explore_gateway_grid_item_img_01} title="History" dstUrl="history" />
         <ExploreGatewayGridItem image={explore_gateway_grid_item_img_02} title="Biology" dstUrl="biology" />

--- a/src/components/homepage/ExploreGatewayIntro.css
+++ b/src/components/homepage/ExploreGatewayIntro.css
@@ -7,9 +7,8 @@
  * Updated  : Aug 08, 2021
  */
 
-div.ExploreGatewayIntro {
-  background-color: rgba(239, 239, 239, 1.0);
-}
+/* div.ExploreGatewayIntro {
+} */
 
 p.JoinTheRace {
   font-size: 24px;

--- a/src/components/homepage/ExploreGatewayIntro.js
+++ b/src/components/homepage/ExploreGatewayIntro.js
@@ -10,14 +10,10 @@
 import React from 'react'
 
 import {
-  Button,
   Container,
   Header,
   Icon,
-  Segment
 } from 'semantic-ui-react'
-
-import FluidSingleRowGrid from '../shared/FluidSingleRowGrid'
 
 import 'semantic-ui-css/semantic.min.css'
 
@@ -25,13 +21,15 @@ import '../shared/GlobalStyles.css'
 
 import '../shared/ContentPageSharedStyles.css'
 
+import './ExploreGatewaySharedStyles.css'
+
 import './ExploreGatewayIntro.css'
 
 import image_CCF_Cheetah_Museum from './assets/CCF_Cheetah_Museum-min.jpg'
 
 export default function ExploreGatewayIntro() {
   return (
-    <div className="ExploreGatewayIntro" data-testid="ExploreGatewayIntroTestId">
+    <div className="ExploreGatewayIntro ExploreGatewayBackground" data-testid="ExploreGatewayIntroTestId">
       <div className="VerticalCushionPadding">
         <img
           className="ExploreGatewayIntroCCFCheetahMuseumImage"
@@ -53,31 +51,6 @@ export default function ExploreGatewayIntro() {
             </p>
           </div>
         </Container>
-      </div>
-
-      <div id="ExploreGatewayMenu" className="ExploreGatewayIntroCenterGrid VerticalCushionPadding">
-        <FluidSingleRowGrid justifyContent="center">
-          <div className="ExploreGatewayIntroCenterGridLhsColumnStyle">
-            <p className="CCFMissionStatementQuote">
-              “CCF is Changing the World to Save the Cheetah” - Dr. Laurie Marker
-            </p>
-          </div>
-          <div className="ExploreGatewayIntroCenterGridRhsColumnStyle">
-            <Segment inverted>
-              <p className="JoinTheRace">
-                Join the race to <a href="https://twitter.com/search?q=%23SaveTheCheetah" target="_blank" rel="noopener noreferrer">
-                  <span className="SafeTheCheetah">
-                    #SafeTheCheetah
-                  </span>
-                </a>
-              </p>
-              <p>Cheetahs can't win without us.</p>
-              <Button basic inverted href="https://cheetah.org/get-involved/ways-to-give/">
-                Get Involved
-              </Button>
-            </Segment>
-          </div>
-        </FluidSingleRowGrid>
       </div>
     </div>
   );

--- a/src/components/homepage/ExploreGatewaySharedStyles.css
+++ b/src/components/homepage/ExploreGatewaySharedStyles.css
@@ -1,0 +1,12 @@
+/**
+ * ExploreGatewaySharedStyles.css
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Aug 08, 2021
+ * Updated  : Aug 08, 2021
+ */
+
+div.ExploreGatewayBackground {
+    background-color: rgba(239, 239, 239, 1.0);
+}

--- a/src/components/homepage/__tests__/ExploreGatewayFooter.test.js
+++ b/src/components/homepage/__tests__/ExploreGatewayFooter.test.js
@@ -1,0 +1,36 @@
+/**
+ * ExploreGatewayFooter.test.js
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Aug 08, 2021
+ * Updated  : Aug 08, 2021
+ */
+
+ import React from 'react'
+
+ import { render, screen } from '@testing-library/react'
+ 
+ import renderer from 'react-test-renderer'
+ 
+ import ExploreGatewayFooter from '../ExploreGatewayFooter'
+ 
+ test('renders explore gateway footer', () => {
+   render(
+     <ExploreGatewayFooter />
+   );
+
+   // Tests 'Get Involved' button is present and have the correct link.
+   const getInvolvedButton = screen.getByText("Get Involved");
+   expect(getInvolvedButton).toBeInTheDocument();
+   expect(getInvolvedButton.href).toBe("https://cheetah.org/get-involved/ways-to-give/");
+ });
+ 
+ test('ExploreGatewayFooter component snapshot', () => {
+   const tree = renderer
+     .create(
+       <ExploreGatewayFooter />
+     ).toJSON();
+   expect(tree).toMatchSnapshot();
+ });
+ 

--- a/src/components/homepage/__tests__/ExploreGatewayIntro.tests.js
+++ b/src/components/homepage/__tests__/ExploreGatewayIntro.tests.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 02, 2020
- * Updated  : Jul 28, 2020
+ * Updated  : Aug 08, 2021
  */
 
 import React from 'react'
@@ -23,11 +23,6 @@ test('renders explore gateway intro', () => {
   // Tests component title is present.
   const componentTitleElement = screen.getByText(/Explore CCF’s Cheetah Museum/i);
   expect(componentTitleElement).toBeInTheDocument();
-
-  // Tests 'Get Involved' button is present and have the correct link.
-  const getInvolvedButton = screen.getByText("Get Involved");
-  expect(getInvolvedButton).toBeInTheDocument();
-  expect(getInvolvedButton.href).toBe("https://cheetah.org/get-involved/ways-to-give/");
 });
 
 test('ExploreGatewayIntro component snapshot', () => {

--- a/src/components/homepage/__tests__/__snapshots__/ExploreGateway.test.js.snap
+++ b/src/components/homepage/__tests__/__snapshots__/ExploreGateway.test.js.snap
@@ -6,7 +6,7 @@ exports[`ExploreGateway component snapshot 1`] = `
   id="Explore"
 >
   <div
-    className="ExploreGatewayIntro"
+    className="ExploreGatewayIntro ExploreGatewayBackground"
     data-testid="ExploreGatewayIntroTestId"
   >
     <div
@@ -50,66 +50,11 @@ exports[`ExploreGateway component snapshot 1`] = `
         </div>
       </div>
     </div>
-    <div
-      className="ExploreGatewayIntroCenterGrid VerticalCushionPadding"
-      id="ExploreGatewayMenu"
-    >
-      <div
-        className="FluidSingleRowGridOuterContainer"
-        style={
-          Object {
-            "justifyContent": "center",
-          }
-        }
-      >
-        <div
-          className="ExploreGatewayIntroCenterGridLhsColumnStyle"
-        >
-          <p
-            className="CCFMissionStatementQuote"
-          >
-            “CCF is Changing the World to Save the Cheetah” - Dr. Laurie Marker
-          </p>
-        </div>
-        <div
-          className="ExploreGatewayIntroCenterGridRhsColumnStyle"
-        >
-          <div
-            className="ui inverted segment"
-          >
-            <p
-              className="JoinTheRace"
-            >
-              Join the race to 
-              <a
-                href="https://twitter.com/search?q=%23SaveTheCheetah"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <span
-                  className="SafeTheCheetah"
-                >
-                  #SafeTheCheetah
-                </span>
-              </a>
-            </p>
-            <p>
-              Cheetahs can't win without us.
-            </p>
-            <a
-              className="ui basic inverted button"
-              href="https://cheetah.org/get-involved/ways-to-give/"
-              onClick={[Function]}
-              role="button"
-            >
-              Get Involved
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
-  <nav>
+  <nav
+    className="ExploreGatewayGrid"
+    id="ExploreGatewayMenu"
+  >
     <div
       className="ui container stackable center aligned four column grid"
       data-testid="ExploreGatewayGridTestId"
@@ -224,6 +169,62 @@ exports[`ExploreGateway component snapshot 1`] = `
       </div>
     </div>
   </nav>
-  <br />
+  <div
+    className="ExploreGatewayFooter ExploreGatewayBackground VerticalCushionPadding"
+  >
+    <div
+      className="FluidSingleRowGridOuterContainer"
+      style={
+        Object {
+          "justifyContent": "center",
+        }
+      }
+    >
+      <div
+        className="ExploreGatewayIntroCenterGridLhsColumnStyle"
+      >
+        <p
+          className="CCFMissionStatementQuote"
+        >
+          “CCF is Changing the World to Save the Cheetah” - Dr. Laurie Marker
+        </p>
+      </div>
+      <div
+        className="ExploreGatewayIntroCenterGridRhsColumnStyle"
+      >
+        <div
+          className="ui inverted segment"
+        >
+          <p
+            className="JoinTheRace"
+          >
+            Join the race to 
+            <a
+              href="https://twitter.com/search?q=%23SaveTheCheetah"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <span
+                className="SafeTheCheetah"
+              >
+                #SafeTheCheetah
+              </span>
+            </a>
+          </p>
+          <p>
+            Cheetahs can't win without us.
+          </p>
+          <a
+            className="ui basic inverted button"
+            href="https://cheetah.org/get-involved/ways-to-give/"
+            onClick={[Function]}
+            role="button"
+          >
+            Get Involved
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/src/components/homepage/__tests__/__snapshots__/ExploreGatewayFooter.test.js.snap
+++ b/src/components/homepage/__tests__/__snapshots__/ExploreGatewayFooter.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExploreGatewayFooter component snapshot 1`] = `
+<div
+  className="ExploreGatewayFooter ExploreGatewayBackground VerticalCushionPadding"
+>
+  <div
+    className="FluidSingleRowGridOuterContainer"
+    style={
+      Object {
+        "justifyContent": "center",
+      }
+    }
+  >
+    <div
+      className="ExploreGatewayIntroCenterGridLhsColumnStyle"
+    >
+      <p
+        className="CCFMissionStatementQuote"
+      >
+        “CCF is Changing the World to Save the Cheetah” - Dr. Laurie Marker
+      </p>
+    </div>
+    <div
+      className="ExploreGatewayIntroCenterGridRhsColumnStyle"
+    >
+      <div
+        className="ui inverted segment"
+      >
+        <p
+          className="JoinTheRace"
+        >
+          Join the race to 
+          <a
+            href="https://twitter.com/search?q=%23SaveTheCheetah"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span
+              className="SafeTheCheetah"
+            >
+              #SafeTheCheetah
+            </span>
+          </a>
+        </p>
+        <p>
+          Cheetahs can't win without us.
+        </p>
+        <a
+          className="ui basic inverted button"
+          href="https://cheetah.org/get-involved/ways-to-give/"
+          onClick={[Function]}
+          role="button"
+        >
+          Get Involved
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/homepage/__tests__/__snapshots__/ExploreGatewayGrid.test.js.snap
+++ b/src/components/homepage/__tests__/__snapshots__/ExploreGatewayGrid.test.js.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ExploreGatewayGrid component snapshot 1`] = `
-<nav>
+<nav
+  className="ExploreGatewayGrid"
+  id="ExploreGatewayMenu"
+>
   <div
     className="ui container stackable center aligned four column grid"
     data-testid="ExploreGatewayGridTestId"

--- a/src/components/homepage/__tests__/__snapshots__/ExploreGatewayIntro.tests.js.snap
+++ b/src/components/homepage/__tests__/__snapshots__/ExploreGatewayIntro.tests.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ExploreGatewayIntro component snapshot 1`] = `
 <div
-  className="ExploreGatewayIntro"
+  className="ExploreGatewayIntro ExploreGatewayBackground"
   data-testid="ExploreGatewayIntroTestId"
 >
   <div
@@ -43,64 +43,6 @@ exports[`ExploreGatewayIntro component snapshot 1`] = `
             />
           </a>
         </p>
-      </div>
-    </div>
-  </div>
-  <div
-    className="ExploreGatewayIntroCenterGrid VerticalCushionPadding"
-    id="ExploreGatewayMenu"
-  >
-    <div
-      className="FluidSingleRowGridOuterContainer"
-      style={
-        Object {
-          "justifyContent": "center",
-        }
-      }
-    >
-      <div
-        className="ExploreGatewayIntroCenterGridLhsColumnStyle"
-      >
-        <p
-          className="CCFMissionStatementQuote"
-        >
-          “CCF is Changing the World to Save the Cheetah” - Dr. Laurie Marker
-        </p>
-      </div>
-      <div
-        className="ExploreGatewayIntroCenterGridRhsColumnStyle"
-      >
-        <div
-          className="ui inverted segment"
-        >
-          <p
-            className="JoinTheRace"
-          >
-            Join the race to 
-            <a
-              href="https://twitter.com/search?q=%23SaveTheCheetah"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              <span
-                className="SafeTheCheetah"
-              >
-                #SafeTheCheetah
-              </span>
-            </a>
-          </p>
-          <p>
-            Cheetahs can't win without us.
-          </p>
-          <a
-            className="ui basic inverted button"
-            href="https://cheetah.org/get-involved/ways-to-give/"
-            onClick={[Function]}
-            role="button"
-          >
-            Get Involved
-          </a>
-        </div>
       </div>
     </div>
   </div>

--- a/src/components/homepage/__tests__/__snapshots__/HomePage.test.js.snap
+++ b/src/components/homepage/__tests__/__snapshots__/HomePage.test.js.snap
@@ -51,7 +51,7 @@ exports[`HomePage snapshot 1`] = `
     id="Explore"
   >
     <div
-      className="ExploreGatewayIntro"
+      className="ExploreGatewayIntro ExploreGatewayBackground"
       data-testid="ExploreGatewayIntroTestId"
     >
       <div
@@ -95,66 +95,11 @@ exports[`HomePage snapshot 1`] = `
           </div>
         </div>
       </div>
-      <div
-        className="ExploreGatewayIntroCenterGrid VerticalCushionPadding"
-        id="ExploreGatewayMenu"
-      >
-        <div
-          className="FluidSingleRowGridOuterContainer"
-          style={
-            Object {
-              "justifyContent": "center",
-            }
-          }
-        >
-          <div
-            className="ExploreGatewayIntroCenterGridLhsColumnStyle"
-          >
-            <p
-              className="CCFMissionStatementQuote"
-            >
-              “CCF is Changing the World to Save the Cheetah” - Dr. Laurie Marker
-            </p>
-          </div>
-          <div
-            className="ExploreGatewayIntroCenterGridRhsColumnStyle"
-          >
-            <div
-              className="ui inverted segment"
-            >
-              <p
-                className="JoinTheRace"
-              >
-                Join the race to 
-                <a
-                  href="https://twitter.com/search?q=%23SaveTheCheetah"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  <span
-                    className="SafeTheCheetah"
-                  >
-                    #SafeTheCheetah
-                  </span>
-                </a>
-              </p>
-              <p>
-                Cheetahs can't win without us.
-              </p>
-              <a
-                className="ui basic inverted button"
-                href="https://cheetah.org/get-involved/ways-to-give/"
-                onClick={[Function]}
-                role="button"
-              >
-                Get Involved
-              </a>
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
-    <nav>
+    <nav
+      className="ExploreGatewayGrid"
+      id="ExploreGatewayMenu"
+    >
       <div
         className="ui container stackable center aligned four column grid"
         data-testid="ExploreGatewayGridTestId"
@@ -269,7 +214,63 @@ exports[`HomePage snapshot 1`] = `
         </div>
       </div>
     </nav>
-    <br />
+    <div
+      className="ExploreGatewayFooter ExploreGatewayBackground VerticalCushionPadding"
+    >
+      <div
+        className="FluidSingleRowGridOuterContainer"
+        style={
+          Object {
+            "justifyContent": "center",
+          }
+        }
+      >
+        <div
+          className="ExploreGatewayIntroCenterGridLhsColumnStyle"
+        >
+          <p
+            className="CCFMissionStatementQuote"
+          >
+            “CCF is Changing the World to Save the Cheetah” - Dr. Laurie Marker
+          </p>
+        </div>
+        <div
+          className="ExploreGatewayIntroCenterGridRhsColumnStyle"
+        >
+          <div
+            className="ui inverted segment"
+          >
+            <p
+              className="JoinTheRace"
+            >
+              Join the race to 
+              <a
+                href="https://twitter.com/search?q=%23SaveTheCheetah"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <span
+                  className="SafeTheCheetah"
+                >
+                  #SafeTheCheetah
+                </span>
+              </a>
+            </p>
+            <p>
+              Cheetahs can't win without us.
+            </p>
+            <a
+              className="ui basic inverted button"
+              href="https://cheetah.org/get-involved/ways-to-give/"
+              onClick={[Function]}
+              role="button"
+            >
+              Get Involved
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <footer>
     <div


### PR DESCRIPTION
This patch introduces minor changes to the layout of the Explore gateway within the home page. Specifically, it moves the Intro and Grid components of the Explore gateway to be adjacent, with the goal of making the navigation intent on the page more clear. The component that has the quote and "Get Involved" subsection has moved to under the Explore grid menu (i.e. refactored into its own component named `ExploreGatewayFooter`).

----

<img width="1359" alt="PR223_Screenshot_iPad12 9" src="https://user-images.githubusercontent.com/554685/128644876-61c3c3ce-2756-459b-9019-37c1d2911794.png">

<img width="549" alt="PR223_Screenshot_iPhone12Mini" src="https://user-images.githubusercontent.com/554685/128644877-dedd7873-6e48-4d1b-a887-4fd84c3503ad.png">
