### PR TITLE
Refine content page local page navigation - Part 2

### DIFF
--- a/src/components/shared/ContentPageBanner.js
+++ b/src/components/shared/ContentPageBanner.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 06, 2020
- * Updated  : Aug 22, 2020
+ * Updated  : Aug 10, 2021
  */
 
 import React from 'react'
@@ -55,6 +55,7 @@ export default class ContentPageBanner extends React.Component {
                                               "ContentPageBannerContainer"])}
         style={contentPageBannerContainerStyles}
         data-testid="ContentPageBannerComponentTestId"
+        id="ContentPageBanner"
       >
         <div className="ContentPageBannerTitleContainer">
           <p className="ContentPageBannerTitle">{this.props.title}</p>

--- a/src/components/shared/ContentPageBottomNavBar.css
+++ b/src/components/shared/ContentPageBottomNavBar.css
@@ -1,0 +1,34 @@
+/**
+ * ContentPageBottomNavBar.css
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Aug 10, 2021
+ * Updated  : Aug 10, 2021
+ */
+
+div.ContentPageBottomNavBarOuterContainer {
+  margin: 0 auto;
+  width: 100%;
+  height: 70px;
+  display: block;
+  padding: 20px;
+
+  border-radius: 20px;
+  background-color: #fff;
+  background-color: rgba(255,255,255,0.45);
+  /* background-color: rgba(10,10,10,0.25); */
+
+  z-index: 9;
+}
+
+div.ContentPageBottomNavBarInnerContainer {
+  width: 100%;
+}
+
+div.ContentPageBottomNavBarIconSetContainer {
+  width: 100%;
+  display: inline-flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+}

--- a/src/components/shared/ContentPageBottomNavBar.js
+++ b/src/components/shared/ContentPageBottomNavBar.js
@@ -1,0 +1,61 @@
+/**
+ * ContentPageBottomNavBar.js
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Aug 10, 2021
+ * Updated  : Aug 10, 2021
+ */
+
+import React from 'react'
+
+import {
+  Icon
+} from 'semantic-ui-react'
+
+import {
+  getElementStyleClassName,
+  getElementStyleClassNames
+} from '../../styling/styling'
+
+import './ContentPageSharedStyles.css'
+
+import './ContentPageBottomNavBar.css'
+
+export default class ContentPageBottomNavBar extends React.Component {
+
+  render() {
+    return (
+      <div className={getElementStyleClassNames(["ContentPageBottomNavBarOuterContainer", "ContentPageSkeletonContentContainerDimension"])}>
+        <div className={getElementStyleClassName("ContentPageBottomNavBarInnerContainer")}>
+          <div className={getElementStyleClassName("ContentPageBottomNavBarIconSetContainer")}>
+            <a href="#">
+              <Icon name='arrow alternate circle up outline' size='big' color='blue'/>
+            </a>
+
+            <a href="#ContentPageBanner">
+              <Icon name='list alternate' size='big' color='orange'/>
+            </a>
+
+            {this.renderPrevNextPageIconButton(this.props.pageTailNavMenu.prevPage, true)}
+            {this.renderPrevNextPageIconButton(this.props.pageTailNavMenu.nextPage, false)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  renderPrevNextPageIconButton(item, isLeft) {
+    const iconName = isLeft ? 'chevron circle left' : 'chevron circle right';
+
+    const disabled = !item;
+
+    const href = item ? item.href : "";
+
+    return (
+      <a href={href} disabled={disabled}>
+        <Icon name={iconName} size='big' color='blue' disabled={disabled}/>
+      </a>
+    );
+  }
+}

--- a/src/components/shared/ContentPageSkeleton.css
+++ b/src/components/shared/ContentPageSkeleton.css
@@ -4,16 +4,42 @@
  *
  * Author   : Tomiko
  * Created  : Jul 06, 2020
- * Updated  : Aug 18, 2020
+ * Updated  : Aug 10, 2021
  */
 
 .ContentPageSkeletonOuterContainer {
-  background-color: rgba(239, 239, 239, 1.0);
+  background-color: rgb(239, 239, 239);
+}
+
+div.ContentPageSkeletonPreContentContainer {
+  position: relative; /** This is to make the z-index attribute below into effect,
+                          as the attribute only works for an element with explicitly defined
+                          position attribute.
+                      */
+
+  z-index: 999;       /** This is to make sure that the `ContentPageBottomNavBar` component
+                          does not occlude the content page banner and section nav menu bar.
+
+                          NOTE: Make sure this has a higher value for the z-index attribute
+                          than the one defined for `ContentPageBottomNavBar` (in ContentPageBottomNavBar.css).
+                      */
 }
 
 div.ContentPageSkeletonContentContainer {
   margin: 0 auto;
   width: 85%;
+}
+
+/** Wrapper container to make the `ContentPageSkeletonBottomNavBar`
+    component appear at a fixed position offset relative
+    to the bottom of its parent container (we want it to have
+    the effect of appearing at the bottom of the screen).
+*/
+div.ContentPageSkeletonBottomNavBarContainer {
+  position: fixed;
+  margin: 0 auto;
+  width: 100%;
+  bottom: 0px;
 }
 
 /** This width specification is kept in sync

--- a/src/components/shared/ContentPageSkeleton.js
+++ b/src/components/shared/ContentPageSkeleton.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 06, 2020
- * Updated  : Aug 20, 2020
+ * Updated  : Aug 10, 2021
  */
 
 import React, { Fragment } from 'react'
@@ -27,6 +27,7 @@ import ContentPageIntroSectionGeneric from './ContentPageIntroSectionGeneric'
 import ContentPageHead from './ContentPageHead'
 import ContentPageTail from './ContentPageTail'
 import ContentPageSideNavMenu from './ContentPageSideNavMenu'
+import ContentPageBottomNavBar from './ContentPageBottomNavBar'
 
 import Footer from './Footer'
 
@@ -81,7 +82,7 @@ export default class ContentPageSkeleton extends React.Component {
 
     const globalMetaKeywords = this.props.appConfig.headMeta.keywords;
     const headMetaKeywords = headMeta.keywords;
-  
+
     const metaKeywords = headMetaKeywords.concat(globalMetaKeywords).join(", ");
 
     return (
@@ -105,7 +106,7 @@ export default class ContentPageSkeleton extends React.Component {
 
   renderHeader() {
     return (
-      <div className="ContentPageSkeletonContentContainerDimension">
+      <div className="ContentPageSkeletonContentContainerDimension ContentPageSkeletonPreContentContainer">
         <ContentPageHead
           pageProps={this.props.pageConfig.pageProps}
           imagesContext={this.props.imagesContext}
@@ -167,6 +168,10 @@ export default class ContentPageSkeleton extends React.Component {
               </div>
             </Sticky>
           </Rail>
+
+          <div className="ContentPageSkeletonBottomNavBarContainer">
+            <ContentPageBottomNavBar pageTailNavMenu={this.props.pageConfig.pageProps.pageTailNavMenu}/>
+          </div>
         </div>
       </Ref>
     );

--- a/src/components/shared/__tests__/__snapshots__/ContentPageBanner.test.js.snap
+++ b/src/components/shared/__tests__/__snapshots__/ContentPageBanner.test.js.snap
@@ -4,6 +4,7 @@ exports[`ContentPageBanner component snapshot 1`] = `
 <div
   className="ContentPageSkeletonContentContainerDimension ContentPageBannerContainer"
   data-testid="ContentPageBannerComponentTestId"
+  id="ContentPageBanner"
   style={
     Object {
       "backgroundImage": "url(null)",

--- a/src/components/shared/__tests__/__snapshots__/ContentPageHead.test.js.snap
+++ b/src/components/shared/__tests__/__snapshots__/ContentPageHead.test.js.snap
@@ -85,6 +85,7 @@ exports[`ContentPageHead component snapshot 1`] = `
     <div
       className="ContentPageSkeletonContentContainerDimension ContentPageBannerContainer"
       data-testid="ContentPageBannerComponentTestId"
+      id="ContentPageBanner"
       style={
         Object {
           "backgroundImage": "url(null)",

--- a/src/components/shared/__tests__/__snapshots__/ContentPageSkeleton.test.js.snap
+++ b/src/components/shared/__tests__/__snapshots__/ContentPageSkeleton.test.js.snap
@@ -5,7 +5,7 @@ exports[`ContentPageSkeleton snapshot 1`] = `
   className="ContentPageSkeletonOuterContainer"
 >
   <div
-    className="ContentPageSkeletonContentContainerDimension"
+    className="ContentPageSkeletonContentContainerDimension ContentPageSkeletonPreContentContainer"
   >
     <header>
       <div
@@ -91,6 +91,7 @@ exports[`ContentPageSkeleton snapshot 1`] = `
         <div
           className="ContentPageSkeletonContentContainerDimension ContentPageBannerContainer"
           data-testid="ContentPageBannerComponentTestId"
+          id="ContentPageBanner"
           style={
             Object {
               "backgroundImage": "url(null)",
@@ -668,6 +669,60 @@ exports[`ContentPageSkeleton snapshot 1`] = `
                 </nav>
               </div>
             </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ContentPageSkeletonBottomNavBarContainer"
+    >
+      <div
+        className="ContentPageBottomNavBarOuterContainer ContentPageSkeletonContentContainerDimension"
+      >
+        <div
+          className="ContentPageBottomNavBarInnerContainer"
+        >
+          <div
+            className="ContentPageBottomNavBarIconSetContainer"
+          >
+            <a
+              href="#"
+            >
+              <i
+                aria-hidden="true"
+                className="blue arrow alternate circle up outline big icon"
+                onClick={[Function]}
+              />
+            </a>
+            <a
+              href="#ContentPageBanner"
+            >
+              <i
+                aria-hidden="true"
+                className="orange list alternate big icon"
+                onClick={[Function]}
+              />
+            </a>
+            <a
+              disabled={false}
+              href="/biology"
+            >
+              <i
+                aria-hidden="true"
+                className="blue chevron circle left big icon"
+                onClick={[Function]}
+              />
+            </a>
+            <a
+              disabled={false}
+              href="/future"
+            >
+              <i
+                aria-hidden="true"
+                className="blue chevron circle right big icon"
+                onClick={[Function]}
+              />
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This patch attempts to address the shortcoming of lacking an effective mechanism within a content page to navigate easily across the page when viewed under a mobile-like display size.

The solution is to introduce a nav menu bar component (i.e. `ContentPageBottomNavBar`) that always appears at the bottom of the screen at a fixed position and offset, and offers navigation links to jump to the top of the page, ToC of the content page, as well as support to navigate to the previous and next connected content pages.

----

<img width="1359" alt="PR226_Screenshot_iPad11inch" src="https://user-images.githubusercontent.com/554685/128898502-a5f05392-4aad-40cd-8924-9ead12f82d58.png">

<img width="549" alt="PR226_Screenshot_iPhone12Mini" src="https://user-images.githubusercontent.com/554685/128898522-3c7cc77d-7613-40bb-b847-4110f294156a.png">