### PR TITLE
[CRITICAL] Fix content page loading error

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "start": "react-scripts start",
     "test": "react-scripts test --runInBand"
   },
-  "version": "0.4.3-alpha.3+08.11.21-0740"
+  "version": "0.4.3-alpha.4+08.11.21-0810"
 }

--- a/src/components/homepage/HomePage.js
+++ b/src/components/homepage/HomePage.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 02, 2020
- * Updated  : Aug 10, 2021
+ * Updated  : Aug 11, 2021
  */
 
 import React, { Fragment } from 'react'
@@ -26,7 +26,6 @@ export default class HomePage extends React.Component {
       <Fragment>
         {this.renderHTMLHead()}
         {this.renderHTMLBody()}
-        {this.renderVersionString()}
       </Fragment>
     );
   }
@@ -41,6 +40,7 @@ export default class HomePage extends React.Component {
         <Footer
           appConfig={this.props.appConfig}
         />
+        {this.renderVersionString()}
       </div>
     )
   }

--- a/src/components/shared/ContentPageSkeleton.js
+++ b/src/components/shared/ContentPageSkeleton.js
@@ -77,7 +77,6 @@ export default class ContentPageSkeleton extends React.Component {
       <Fragment>
         {this.renderHTMLHead()}
         {this.renderHTMLBody()}
-        {this.renderVersionString()}
       </Fragment>
     );
   }
@@ -105,6 +104,7 @@ export default class ContentPageSkeleton extends React.Component {
         {this.renderHeader()}
         {this.renderBody()}
         {this.renderFooter()}
+        {this.renderVersionString()}
       </div>
     );
   }


### PR DESCRIPTION
This patch attempts to address a critical issue where content pages fail to load successfully on first load.

This issue seems to stem from the change made in #227 (b127792) where the migration of project version string HTML comments to a direct descendent of the root node seem to cause issues to React when page loads to the next content page.

In addition, this patch also updates `versionutil.py` to be able to update prerelease or build component of version string without having to bump any of the major, minor, or patch components.

Bumped version to `0.4.3-alpha.4+08.11.21-0810`