### PR TITLE
Workaround for require.context

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "start": "react-scripts start",
     "test": "react-scripts test --runInBand"
   },
-  "version": "0.5.2"
+  "version": "0.5.3-alpha.1+08.21.21-1555"
 }

--- a/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
+++ b/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 16, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React, { Suspense } from 'react'
@@ -20,6 +20,8 @@ import ContentPageSideFloatFluidContainer from '../shared/ContentPageSideFloatFl
 import {
   ContentPageSubsectionParagraphsJoin
 } from '../shared/ContentPageSubsectionContentBinder'
+
+import { requireContext } from '../shared/workarounds/RequireContextMock'
 
 import { GetImagePath } from '../shared/Path'
 
@@ -47,8 +49,7 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFeetAndClaws._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFeetAndClaws._SUBSECTION_NAME_]
     };
   }
 
@@ -134,7 +135,8 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
   }
 
   renderClawsComparisonImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ImageView

--- a/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
+++ b/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
@@ -49,8 +49,7 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFeetAndClaws._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFeetAndClaws._SUBSECTION_NAME_]
     };
   }
 
@@ -136,7 +135,8 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
   }
 
   renderClawsComparisonImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ImageView

--- a/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
+++ b/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
@@ -135,8 +135,8 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
   }
 
   renderClawsComparisonImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <ImageView

--- a/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
+++ b/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
@@ -49,7 +49,8 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFeetAndClaws._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFeetAndClaws._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -135,8 +136,7 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
   }
 
   renderClawsComparisonImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <ImageView

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
@@ -36,7 +36,8 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage3._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage3._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -82,8 +83,7 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
   }
 
   renderWhatIsDiurnalImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <FactBannerImage

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
@@ -36,8 +36,7 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage3._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage3._SUBSECTION_NAME_]
     };
   }
 
@@ -83,7 +82,8 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
   }
 
   renderWhatIsDiurnalImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 15, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -18,6 +18,8 @@ import ContentPageSubsectionTemplate from '../shared/ContentPageSubsectionTempla
 import {
   ContentPageSubsectionParagraphsContentBinder
 } from '../shared/ContentPageSubsectionContentBinder'
+
+import { requireContext } from '../shared/workarounds/RequireContextMock'
 
 import { GetImagePath } from '../shared/Path'
 
@@ -34,8 +36,7 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage3._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage3._SUBSECTION_NAME_]
     };
   }
 
@@ -81,7 +82,8 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
   }
 
   renderWhatIsDiurnalImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
@@ -82,8 +82,8 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
   }
 
   renderWhatIsDiurnalImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <FactBannerImage

--- a/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
+++ b/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
@@ -49,7 +49,8 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSpotsAndStripes._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSpotsAndStripes._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -99,8 +100,7 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   }
 
   renderWhatIsCamouflageImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <FactBannerImage
@@ -150,8 +150,7 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   }
 
   renderCheetahAndBadgerImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <ImageView

--- a/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
+++ b/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 17, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React, { Suspense } from 'react'
@@ -19,6 +19,8 @@ import ContentPageSubsectionPart from '../shared/ContentPageSubsectionPart'
 import {
   ContentPageSubsectionParagraphsContentBinder
 } from '../shared/ContentPageSubsectionContentBinder'
+
+import { requireContext } from '../shared/workarounds/RequireContextMock'
 
 import { GetImagePath } from '../shared/Path'
 
@@ -47,8 +49,7 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSpotsAndStripes._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSpotsAndStripes._SUBSECTION_NAME_]
     };
   }
 
@@ -98,7 +99,8 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   }
 
   renderWhatIsCamouflageImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage
@@ -148,7 +150,8 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   }
 
   renderCheetahAndBadgerImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ImageView

--- a/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
+++ b/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
@@ -49,8 +49,7 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSpotsAndStripes._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSpotsAndStripes._SUBSECTION_NAME_]
     };
   }
 
@@ -100,7 +99,8 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   }
 
   renderWhatIsCamouflageImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage
@@ -150,7 +150,8 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   }
 
   renderCheetahAndBadgerImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ImageView

--- a/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
+++ b/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
@@ -99,8 +99,8 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   }
 
   renderWhatIsCamouflageImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <FactBannerImage

--- a/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
+++ b/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
@@ -150,8 +150,8 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   }
 
   renderCheetahAndBadgerImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <ImageView

--- a/src/components/biology/__tests__/BiologyPage_Section_Lifecycle.test.js
+++ b/src/components/biology/__tests__/BiologyPage_Section_Lifecycle.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 15, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -18,21 +18,13 @@ import renderer from 'react-test-renderer'
 import BiologyPageSectionLifecyle from '../BiologyPage_Section_Lifecycle'
 
 test('renders BiologyPageSectionLifecyle component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(<BiologyPageSectionLifecyle config={config}/>);
+  render(<BiologyPageSectionLifecyle config={config}/>);
 });
 
 test('BiologyPageSectionLifecyle component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <BiologyPageSectionLifecyle config={config}/>)
-  //   .toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <BiologyPageSectionLifecyle config={config}/>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/biology/__tests__/BiologyPage_Section_Physiology.test.js
+++ b/src/components/biology/__tests__/BiologyPage_Section_Physiology.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 19, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,11 +20,7 @@ import { RUN_TEST_NEVER } from '../../../testing/testing'
 import BiologyPageSectionPhysiology from '../BiologyPage_Section_Physiology'
 
 test('renders BiologyPageSectionPhysiology component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(<BiologyPageSectionPhysiology config={config}/>);
+  render(<BiologyPageSectionPhysiology config={config}/>);
 });
 
 /**
@@ -32,14 +28,10 @@ test('renders BiologyPageSectionPhysiology component', () => {
  */
 RUN_TEST_NEVER(() => {
   test('BiologyPageSectionPhysiology component snapshot', () => {
-    /**
-     * Disable test because we currently use require.context
-     * and it doesn't work in Jest.
-     */
-    // const tree = renderer
-    //   .create(
-    //     <BiologyPageSectionPhysiology config={config}/>)
-    //   .toJSON();
-    // expect(tree).toMatchSnapshot();
+    const tree = renderer
+      .create(
+        <BiologyPageSectionPhysiology config={config}/>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/src/components/biology/__tests__/BiologyPage_Subsection_FeetAndClaws.test.js
+++ b/src/components/biology/__tests__/BiologyPage_Subsection_FeetAndClaws.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 19, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import BiologyPageSubsectionFeetAndClaws from '../BiologyPage_Subsection_FeetAnd
 const sectionConfig = config.contentPageSections["section_Physiology"];
 
 test('renders BiologyPageSubsectionFeetAndClaws component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <BiologyPageSubsectionFeetAndClaws
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <BiologyPageSubsectionFeetAndClaws
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('BiologyPageSubsectionFeetAndClaws component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <BiologyPageSubsectionFeetAndClaws
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <BiologyPageSubsectionFeetAndClaws
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/biology/__tests__/BiologyPage_Subsection_Lifecycle_Stage_3.test.js
+++ b/src/components/biology/__tests__/BiologyPage_Subsection_Lifecycle_Stage_3.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 19, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import BiologyPageSubsectionLifecycleStage3 from '../BiologyPage_Subsection_Life
 const sectionConfig = config.contentPageSections["section_Lifecycle"];
 
 test('renders BiologyPageSubsectionLifecycleStage3 component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <BiologyPageSubsectionLifecycleStage3
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <BiologyPageSubsectionLifecycleStage3
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('BiologyPageSubsectionLifecycleStage3 component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <BiologyPageSubsectionLifecycleStage3
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <BiologyPageSubsectionLifecycleStage3
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/biology/__tests__/BiologyPage_Subsection_SpotsAndStripes.test.js
+++ b/src/components/biology/__tests__/BiologyPage_Subsection_SpotsAndStripes.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 19, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import BiologyPageSubsectionSpotsAndStripes from '../BiologyPage_Subsection_Spot
 const sectionConfig = config.contentPageSections["section_Physiology"];
 
 test('renders BiologyPageSubsectionSpotsAndStripes component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <BiologyPageSubsectionSpotsAndStripes
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <BiologyPageSubsectionSpotsAndStripes
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('BiologyPageSubsectionSpotsAndStripes component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <BiologyPageSubsectionSpotsAndStripes
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <BiologyPageSubsectionSpotsAndStripes
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Section_Lifecycle.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Section_Lifecycle.test.js.snap
@@ -1,0 +1,695 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BiologyPageSectionLifecyle component snapshot 1`] = `
+<article
+  className="ContentPageSectionTemplateOuterContainer"
+>
+  <h2
+    className="ContentPageSectionHeadTitle"
+    id="lifecycle"
+  >
+    Lifecycle
+  </h2>
+  <p
+    className="ContentPageHeadAndSectionIntroText"
+  >
+    One of the most incredible things about the cheetahs is the remarkable processes and transitions in their lifecycle. From born at an average weight of 350 grams and completely helpless and unable to see, to becoming one of the most skilled predators and the fastest land animal on the planet, nothing speaks more about the incredible adaptations that allow them to survive and thrive in the challenging environments where they live.
+  </p>
+  <div
+    className="BiologyPageLifecycleDiagramOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle TextCentered"
+    >
+      The Cycle of Life
+    </h3>
+    <p
+      className="BiologyPageLifecycleDiagramSubtitle TextCentered"
+    >
+      There are four stages in the lifecycle of the cheetah.
+    </p>
+    <p
+      className="BiologyPageLifecycleDiagramContentText TextCentered"
+    >
+      <b>
+        Stage 1
+      </b>
+      : 90 to 95 days pregnancy; 
+      <b>
+        Stage 2
+      </b>
+      : 6 weeks to 18 months;
+    </p>
+    <p
+      className="BiologyPageLifecycleDiagramContentText TextCentered"
+    >
+      <b>
+        Stage 3
+      </b>
+      : 18 to 22 months; 
+      <b>
+        Stage 4
+      </b>
+      : adult life.
+    </p>
+    <img
+      alt="lifecycle diagram"
+      className="FullWidth DisplayBlock RetainAspectRatio Centered"
+      src="Lifecycle_Diagram-min.png"
+      width={640}
+    />
+  </div>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Stage 1
+    </h3>
+    <div
+      className="ContentPageSideFloatFluidContainerOuterContainer"
+    >
+      <div
+        className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+      >
+        <div
+          className="ImageViewOuterContainer"
+          style={
+            Object {
+              "maxWidth": 320,
+            }
+          }
+        >
+          <div
+            className="ImageViewInnerContainer"
+          >
+            <div
+              className="ImageViewImgContainer"
+            >
+              <img
+                alt="Cheetah cubs are born blind, so they need their mother's care."
+                className="ImageViewImg"
+                src="cheetah_mom_carry_cub-min.jpg"
+              />
+            </div>
+            <div
+              className="ImageViewCaptionContainer"
+            >
+              <div
+                className="CaptionContainer"
+                data-testid="CaptionComponentTestId"
+                style={
+                  Object {
+                    "maxWidth": 320,
+                  }
+                }
+              >
+                <div
+                  className="IconContainer"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="image icon"
+                    onClick={[Function]}
+                  />
+                </div>
+                <p
+                  className="ContentPageCaptionTextSize CaptionText"
+                >
+                  Cheetah cubs are born blind, so they need their mother's care.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSideFloatFluidContainerFixedPartContainer"
+      >
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          The female’s gestation period lasts 90 to 95 days. This means she is pregnant for about three months.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Shortly before she is ready to give birth, the mother makes a den in a quiet hidden spot. She chooses her location in the tall grass and thick underbrush or near a clump of rocks.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          A cheetah gives birth to an average of five to six cubs. Each cub weights between 250 to 425 grams. Cubs are born completely helpless and with their eyes closed, but they develop rapidly. Scent and touch are used to find their mother’s nipples to suckle.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          They start crawling around the nest area at four to ten days when their eyes begin to open. At three weeks their teeth break through the gums.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          A mother cheetah will frequently move her litter. This prevents a build-up of scent of the den site, which may lead other predators to the cubs. She carries very young cubs in her jaws.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          The cubs are very vulnerable to lions, hyenas and other predators when the female leaves them alone. When hunting she may be away for up to 48 hours. In Tanzania’s Serengeti National Park, 90% of all cubs do not reach the age of 3 months! Other causes of death are abandonment when prey is scarce, exposure due to low temperatures or grass fires.
+        </p>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Stage 2
+    </h3>
+    <div>
+      <div
+        className="FluidTwoColumnContainerOuterContainer"
+      >
+        <div
+          className="FluidTwoColumnContainerColumnContainer FluidTwoColumnLhsContainerColumnContainer"
+        >
+          <div
+            className="ContentPageSubsectionPartContainer"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              At 1.5 to 2 months of age, the cubs leave the safety of the den to accompany their mother. They are very vulnerable as they are not able to defend themselves.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              They stop drinking their mother’s milk at 3 to 4 months of age. They start eating meat and learning to hunt. The games they play and the experiences they have during this stage will teach them skills needed to survive on their own.
+            </p>
+          </div>
+        </div>
+        <div
+          className="FluidTwoColumnContainerColumnContainer FluidTwoColumnRhsContainerColumnContainer"
+        >
+          <div
+            className="ContentPageSubsectionPartContainer"
+          >
+            <div
+              className="Centered FullWidth"
+              style={
+                Object {
+                  "width": 560,
+                }
+              }
+            >
+              <iframe
+                allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen={true}
+                className="FullWidth"
+                frameBorder="0"
+                height={315}
+                src="https://www.youtube.com/embed/Wjtb7XMZlgY"
+                title="Cheetah Mom Teaches Cubs to Hunt | YouTube"
+                width={560}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Learning to Hunt
+    </h3>
+    <div
+      className="ContentPageSideFloatFluidContainerOuterContainer"
+    >
+      <div
+        className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+      >
+        <div
+          className="ImageViewOuterContainer"
+          style={
+            Object {
+              "maxWidth": 480,
+            }
+          }
+        >
+          <div
+            className="ImageViewInnerContainer"
+          >
+            <div
+              className="ImageViewImgContainer"
+            >
+              <img
+                alt="Cheetah cubs learning how to hunt."
+                className="ImageViewImg"
+                src="cheetah_cubs_learning_hunting-min.jpg"
+              />
+            </div>
+            <div
+              className="ImageViewCaptionContainer"
+            >
+              <div
+                className="CaptionContainer"
+                data-testid="CaptionComponentTestId"
+                style={
+                  Object {
+                    "maxWidth": 480,
+                  }
+                }
+              >
+                <div
+                  className="IconContainer"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="image icon"
+                    onClick={[Function]}
+                  />
+                </div>
+                <p
+                  className="ContentPageCaptionTextSize CaptionText"
+                >
+                  Cheetah cubs learning how to hunt.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSideFloatFluidContainerFixedPartContainer FloatLeft"
+      >
+        <div
+          className="TextBubbleOuterContainerFlexWrapper"
+        >
+          <div
+            className="TextBubbleOuterContainer"
+            style={
+              Object {
+                "backgroundColor": "rgb(undefined)",
+                "maxWidth": 520,
+                "minHeight": 520,
+              }
+            }
+          >
+            <div
+              className="TextBubbleInnerContainer"
+            >
+              <div
+                className="TextBubbleInnerCore"
+              >
+                <h1
+                  style={
+                    Object {
+                      "color": "rgb(undefined)",
+                      "fontSize": 41.6,
+                    }
+                  }
+                >
+                  Learning to Hunt
+                </h1>
+                <p
+                  style={
+                    Object {
+                      "color": "rgb(undefined)",
+                      "fontSize": 21,
+                    }
+                  }
+                >
+                  The mother brings live prey, such as a young gazelle, to the 9 to 12 month old cubs. She releases it in front of them and the cubs attempt to catch it. 
+                  This allows the cubs to practice their hunting skills while still under her supervision. Accurate timing and coordination during a hunt are important for their future survival. 
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Stage 3
+    </h3>
+    <div>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Stage three begins at the age 18 to 22 months when the cubs have grown to sub-adults and leave their mother. The sub-adults will remain together for up to six more months. At first, their success rate at capturing prey is poor.
+      </p>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Cheetahs are diurnal, hunting mornings and early evenings. They rely on their sight to find prey. They spend most of the day resting under shady trees or on termite mounds. Night hunting is only done during a bright moon.
+      </p>
+      <div>
+        <a
+          href="https://www.nationalgeographic.co.uk/animals/2017/12/stunning-pictures-cheetahs-action"
+        >
+          <button
+            className="ui blue icon button"
+            onClick={[Function]}
+          >
+            Stunning Pictures of Cheetahs in Action | National Geographic
+            <i
+              aria-hidden="true"
+              className="file image icon"
+              onClick={[Function]}
+            />
+          </button>
+        </a>
+      </div>
+      <img
+        alt="What is diurnal?"
+        className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerSmallDimension"
+        src="What_is_Diurnal_L-min.png"
+      />
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Stage 4
+    </h3>
+    <div>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        In Stage 4, cheetahs become sexually mature. Although they are mature at 16 to 18 months, most do not breed until they are three to five years old.
+      </p>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        At 20 - 30 months of age, females leave their litter-mates to find suitable mates and start their own families. They raise their families on their own without the help of the males.
+      </p>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Males usually do not breed until they are 4 to 5 years of age, and dominant in a territory. They live alone, or brothers form permanent groups called "coalitions". These groups stay together for life, claim territories, hunt and find mates together.
+      </p>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Finding a Mate
+    </h3>
+    <div
+      className="ContentPageSideFloatFluidContainerOuterContainer"
+    >
+      <div
+        className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+      >
+        <div
+          className="ImageViewOuterContainer"
+          style={
+            Object {
+              "maxWidth": 720,
+            }
+          }
+        >
+          <div
+            className="ImageViewInnerContainer"
+          >
+            <div
+              className="ImageViewImgContainer"
+            >
+              <img
+                alt="Cheetahs often mark their scent on tree trunks with their urine. This behavior is common among cats."
+                className="ImageViewImg"
+                src="cheetah_scent_marking-min.jpg"
+              />
+            </div>
+            <div
+              className="ImageViewCaptionContainer"
+            >
+              <div
+                className="CaptionContainer"
+                data-testid="CaptionComponentTestId"
+                style={
+                  Object {
+                    "maxWidth": 720,
+                  }
+                }
+              >
+                <div
+                  className="IconContainer"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="image icon"
+                    onClick={[Function]}
+                  />
+                </div>
+                <p
+                  className="ContentPageCaptionTextSize CaptionText"
+                >
+                  Cheetahs often mark their scent on tree trunks with their urine. This behavior is common among cats.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSideFloatFluidContainerFixedPartContainer"
+      >
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          The range of a female offspring may partially overlap that of her mother. Namibian cheetahs are more social than those reported in other countries. Females are often seen with multiple adults and cubs of varying ages.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Female cheetahs are polyoestrous, which means there is no regular breeding season. If not bred, females come into heat (estrus) several times a year. Estrus means they are ready to breed. If cubs are lost to predators females soon come into estrus again.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Smell, sound, and behavioral stimuli attract males to females. Female cheetahs leave a scent trail by releasing sex hormones in urine and feces. They mark trees and bushes. This behavior increases during courtship.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          When courtship takes place, males will follow females closely and mock fighting may be observed.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          When a female is ready to mate, she adopts a receptive posture. The male mounts the female, bites the back of her neck, and breeding takes place. When the male dismounts the female she rolls over on her back and swats at him.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Mating will take place for one to several days and ends when the male loses interest in the female and leaves. Males do not help raise the cubs.
+        </p>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Living Fast - Dying Young
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+          >
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+            >
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Male coalitions
+              </h4>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                A coalition consists of a group of male siblings of the same litter or young unrelated males that have joined together. A hierarchy develops among the males within a coalition.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Young males are usually chased away from their birth range by dominant breeding males. They may establish home ranges more than 100 km away. A coalition is more successful in acquiring and holding territories and in defending kills than single males. This competition can result in mortality among males.
+              </p>
+            </div>
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+            >
+              <div
+                className="ImageViewOuterContainer"
+                style={
+                  Object {
+                    "maxWidth": 510,
+                  }
+                }
+              >
+                <div
+                  className="ImageViewInnerContainer"
+                >
+                  <div
+                    className="ImageViewImgContainer"
+                  >
+                    <img
+                      alt="A coalition of cheetahs on the lookout."
+                      className="ImageViewImg"
+                      src="cheetah_coalition-min.jpg"
+                    />
+                  </div>
+                  <div
+                    className="ImageViewCaptionContainer"
+                  >
+                    <div
+                      className="CaptionContainer"
+                      data-testid="CaptionComponentTestId"
+                      style={
+                        Object {
+                          "maxWidth": 510,
+                        }
+                      }
+                    >
+                      <div
+                        className="IconContainer"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="image icon"
+                          onClick={[Function]}
+                        />
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize CaptionText"
+                      >
+                        A coalition of cheetahs on the lookout.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+          >
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+            >
+              <div
+                className="ImageViewOuterContainer"
+                style={
+                  Object {
+                    "maxWidth": 640,
+                  }
+                }
+              >
+                <div
+                  className="ImageViewInnerContainer"
+                >
+                  <div
+                    className="ImageViewImgContainer"
+                  >
+                    <img
+                      alt="Cheetahs often have to come to face hyenas in competition of food."
+                      className="ImageViewImg"
+                      src="cheetah_face_hyena-min.jpg"
+                    />
+                  </div>
+                  <div
+                    className="ImageViewCaptionContainer"
+                  >
+                    <div
+                      className="CaptionContainer"
+                      data-testid="CaptionComponentTestId"
+                      style={
+                        Object {
+                          "maxWidth": 640,
+                        }
+                      }
+                    >
+                      <div
+                        className="IconContainer"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="image icon"
+                          onClick={[Function]}
+                        />
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize CaptionText"
+                      >
+                        Cheetahs often have to come to face hyenas in competition of food. (Image credit: Steve Volkwyn)
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+            >
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Mortality
+              </h4>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                The cheetah’s lifespan is poorly documented in the wild. A radio collared cheetah lived to be almost 7 years of age in Tanzania’s Serengeti National Park, and one of CCF’s radio collared cheetahs in Namibia lived for over 10 years.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Adult mortality is one of the most significant limiting factors for cheetah population growth and survival. Poaching, competition with large predators and farmers, and loss of habitats and prey are factors attributing to early death.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Though cub deaths are high, cheetahs have evolved to reproduce rapidly in response to this mortality.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</article>
+`;

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_FeetAndClaws.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_FeetAndClaws.test.js.snap
@@ -1,0 +1,690 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BiologyPageSubsectionFeetAndClaws component snapshot 1`] = `
+<section
+  className="ContentPageSubsectionTemplateOuterContainer"
+>
+  <h3
+    className="ContentPageSubsectionTitle"
+  >
+    Feet and Claws
+  </h3>
+  <div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <div
+        className="ContentPageSideFloatFluidContainerOuterContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 403,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="The paws of the cheetah have a distinct shape compared to some of the other carnivores."
+                  className="ImageViewImg"
+                  src="cheetah_paw-min.jpg"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 403,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    The paws of the cheetah have a distinct shape compared to some of the other carnivores.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSideFloatFluidContainerFixedPartContainer FloatLeft"
+        >
+          <div
+            className="TextBubbleOuterContainerFlexWrapper"
+          >
+            <div
+              className="TextBubbleOuterContainer"
+              style={
+                Object {
+                  "backgroundColor": "rgb(undefined)",
+                  "maxWidth": 520,
+                  "minHeight": 520,
+                }
+              }
+            >
+              <div
+                className="TextBubbleInnerContainer"
+              >
+                <div
+                  className="TextBubbleInnerCore"
+                >
+                  <h1
+                    style={
+                      Object {
+                        "color": "rgb(undefined)",
+                        "fontSize": 41.6,
+                      }
+                    }
+                  >
+                    Foot
+                  </h1>
+                  <p
+                    style={
+                      Object {
+                        "color": "rgb(undefined)",
+                        "fontSize": 21,
+                      }
+                    }
+                  >
+                    Cheetah’s foot pads are hard and less rounded than the other cats. The pads function like tire threads providing them with increased traction in fast, sharp turns. 
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <div
+        className="ContentPageSideFloatFluidContainerOuterContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+        >
+          <div
+            className="TextBubbleOuterContainerFlexWrapper"
+          >
+            <div
+              className="TextBubbleOuterContainer"
+              style={
+                Object {
+                  "backgroundColor": "rgb(undefined)",
+                  "maxWidth": 490,
+                  "minHeight": 490,
+                }
+              }
+            >
+              <div
+                className="TextBubbleInnerContainer"
+              >
+                <div
+                  className="TextBubbleInnerCore"
+                >
+                  <h1
+                    style={
+                      Object {
+                        "color": "rgb(undefined)",
+                        "fontSize": 39.2,
+                      }
+                    }
+                  >
+                    Claw
+                  </h1>
+                  <p
+                    style={
+                      Object {
+                        "color": "rgb(undefined)",
+                        "fontSize": 21,
+                      }
+                    }
+                  >
+                    The short blunt claws work like the cleats on a track shoe. They grip the ground for traction when running and help increase speed. 
+                    Cheetah’s claws are semi-retractable, meaning they do not completely retract like the claws of other cats. The foot structure of the cheetah is very dog-like. 
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSideFloatFluidContainerFixedPartContainer FloatLeft"
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 480,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="Compare the cheetah's claws to that of the dogs and other cats, it's somewhere in between in terms of retractability."
+                  className="ImageViewImg"
+                  src="Cheetah_Cat_Dog_Claws_Comparison_Inverted_L-min.png"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 480,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    Compare the cheetah's claws to that of the dogs and other cats, it's somewhere in between in terms of retractability.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <div
+        className="ContentPageSideFloatFluidContainerOuterContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 480,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="Cheetah dewclaw."
+                  className="ImageViewImg"
+                  src="cheetah_dewclaw-min.jpg"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 480,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    Cheetah dewclaw.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSideFloatFluidContainerFixedPartContainer FloatLeft"
+        >
+          <div
+            className="TextBubbleOuterContainerFlexWrapper"
+          >
+            <div
+              className="TextBubbleOuterContainer"
+              style={
+                Object {
+                  "backgroundColor": "rgb(undefined)",
+                  "maxWidth": 520,
+                  "minHeight": 520,
+                }
+              }
+            >
+              <div
+                className="TextBubbleInnerContainer"
+              >
+                <div
+                  className="TextBubbleInnerCore"
+                >
+                  <h1
+                    style={
+                      Object {
+                        "color": "rgb(undefined)",
+                        "fontSize": 41.6,
+                      }
+                    }
+                  >
+                    Dewclaw
+                  </h1>
+                  <p
+                    style={
+                      Object {
+                        "color": "rgb(undefined)",
+                        "fontSize": 21,
+                      }
+                    }
+                  >
+                    The dewclaws of the cheetah are located on the upper inside area of the front foot. These are sharp and frequently used to hook and hold prey. 
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="VerticalCushionPadding"
+        />
+        <div
+          className="AfricanWildlifeTracksIllustrationPageWrapper"
+        >
+          <div
+            className="AfricanWildlifeTracksIllustrationOuterContainer"
+          >
+            <div>
+              <h4
+                className="IllustrationFontName IllustrationTitleFontSize TextCentered"
+              >
+                Footprints (spoor)
+              </h4>
+              <h5
+                className="IllustrationFontName IllustrationSubtitleFontSize TextCentered"
+              >
+                Identify the spoor of these animals
+              </h5>
+              <div
+                className="ui five column grid"
+              >
+                <div
+                  className="row"
+                >
+                  <div
+                    className="column"
+                  >
+                    <div
+                      className="AfricanWildlifeTracksIllustrationItemContainer"
+                    >
+                      <div
+                        className="AfricanWildlifeTracksIllustrationTextRevealContainer"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                            }
+                          }
+                        >
+                          <div
+                            className="ui fade reveal"
+                            data-testid="TextRevealComponentTestId"
+                          >
+                            <div
+                              className="ui visible content"
+                              data-testid="TextRevealComponentVisiblePartTestId"
+                            >
+                              <div
+                                className="TextRevealComponentCoverContainerDiv"
+                              >
+                                <img
+                                  className="ui image"
+                                  src="Spoor_Track_Cheetah-min.jpg"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ui hidden content"
+                              data-testid="TextRevealComponentHiddenPartTestId"
+                            >
+                              <div
+                                className="TextRevealComponentContentContainerDiv"
+                                style={
+                                  Object {
+                                    "backgroundColor": "#feb628",
+                                  }
+                                }
+                              >
+                                <p
+                                  className="TextRevealComponentDescriptionText"
+                                  data-testid="TextRevealComponentDescriptionTextPartTestId"
+                                >
+                                  Cheetah
+                                </p>
+                                <p
+                                  className="TextRevealComponentCaptionText"
+                                  data-testid="TextRevealComponentCaptionTextPartTestId"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="column"
+                  >
+                    <div
+                      className="AfricanWildlifeTracksIllustrationItemContainer"
+                    >
+                      <div
+                        className="AfricanWildlifeTracksIllustrationTextRevealContainer"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                            }
+                          }
+                        >
+                          <div
+                            className="ui fade reveal"
+                            data-testid="TextRevealComponentTestId"
+                          >
+                            <div
+                              className="ui visible content"
+                              data-testid="TextRevealComponentVisiblePartTestId"
+                            >
+                              <div
+                                className="TextRevealComponentCoverContainerDiv"
+                              >
+                                <img
+                                  className="ui image"
+                                  src="Spoor_Track_Leopard-min.jpg"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ui hidden content"
+                              data-testid="TextRevealComponentHiddenPartTestId"
+                            >
+                              <div
+                                className="TextRevealComponentContentContainerDiv"
+                                style={
+                                  Object {
+                                    "backgroundColor": "#feb628",
+                                  }
+                                }
+                              >
+                                <p
+                                  className="TextRevealComponentDescriptionText"
+                                  data-testid="TextRevealComponentDescriptionTextPartTestId"
+                                >
+                                  Leopard
+                                </p>
+                                <p
+                                  className="TextRevealComponentCaptionText"
+                                  data-testid="TextRevealComponentCaptionTextPartTestId"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="column"
+                  >
+                    <div
+                      className="AfricanWildlifeTracksIllustrationItemContainer"
+                    >
+                      <div
+                        className="AfricanWildlifeTracksIllustrationTextRevealContainer"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                            }
+                          }
+                        >
+                          <div
+                            className="ui fade reveal"
+                            data-testid="TextRevealComponentTestId"
+                          >
+                            <div
+                              className="ui visible content"
+                              data-testid="TextRevealComponentVisiblePartTestId"
+                            >
+                              <div
+                                className="TextRevealComponentCoverContainerDiv"
+                              >
+                                <img
+                                  className="ui image"
+                                  src="Spoor_Track_Lion-min.jpg"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ui hidden content"
+                              data-testid="TextRevealComponentHiddenPartTestId"
+                            >
+                              <div
+                                className="TextRevealComponentContentContainerDiv"
+                                style={
+                                  Object {
+                                    "backgroundColor": "#feb628",
+                                  }
+                                }
+                              >
+                                <p
+                                  className="TextRevealComponentDescriptionText"
+                                  data-testid="TextRevealComponentDescriptionTextPartTestId"
+                                >
+                                  Lion
+                                </p>
+                                <p
+                                  className="TextRevealComponentCaptionText"
+                                  data-testid="TextRevealComponentCaptionTextPartTestId"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="column"
+                  >
+                    <div
+                      className="AfricanWildlifeTracksIllustrationItemContainer"
+                    >
+                      <div
+                        className="AfricanWildlifeTracksIllustrationTextRevealContainer"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                            }
+                          }
+                        >
+                          <div
+                            className="ui fade reveal"
+                            data-testid="TextRevealComponentTestId"
+                          >
+                            <div
+                              className="ui visible content"
+                              data-testid="TextRevealComponentVisiblePartTestId"
+                            >
+                              <div
+                                className="TextRevealComponentCoverContainerDiv"
+                              >
+                                <img
+                                  className="ui image"
+                                  src="Spoor_Track_Spotted_Hyena-min.jpg"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ui hidden content"
+                              data-testid="TextRevealComponentHiddenPartTestId"
+                            >
+                              <div
+                                className="TextRevealComponentContentContainerDiv"
+                                style={
+                                  Object {
+                                    "backgroundColor": "#feb628",
+                                  }
+                                }
+                              >
+                                <p
+                                  className="TextRevealComponentDescriptionText"
+                                  data-testid="TextRevealComponentDescriptionTextPartTestId"
+                                >
+                                  Spotted hyena
+                                </p>
+                                <p
+                                  className="TextRevealComponentCaptionText"
+                                  data-testid="TextRevealComponentCaptionTextPartTestId"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="column"
+                  >
+                    <div
+                      className="AfricanWildlifeTracksIllustrationItemContainer"
+                    >
+                      <div
+                        className="AfricanWildlifeTracksIllustrationTextRevealContainer"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                            }
+                          }
+                        >
+                          <div
+                            className="ui fade reveal"
+                            data-testid="TextRevealComponentTestId"
+                          >
+                            <div
+                              className="ui visible content"
+                              data-testid="TextRevealComponentVisiblePartTestId"
+                            >
+                              <div
+                                className="TextRevealComponentCoverContainerDiv"
+                              >
+                                <img
+                                  className="ui image"
+                                  src="Spoor_Track_Wild_Dog-min.jpg"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ui hidden content"
+                              data-testid="TextRevealComponentHiddenPartTestId"
+                            >
+                              <div
+                                className="TextRevealComponentContentContainerDiv"
+                                style={
+                                  Object {
+                                    "backgroundColor": "#feb628",
+                                  }
+                                }
+                              >
+                                <p
+                                  className="TextRevealComponentDescriptionText"
+                                  data-testid="TextRevealComponentDescriptionTextPartTestId"
+                                >
+                                  African wild dog
+                                </p>
+                                <p
+                                  className="TextRevealComponentCaptionText"
+                                  data-testid="TextRevealComponentCaptionTextPartTestId"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_3.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_3.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BiologyPageSubsectionLifecycleStage3 component snapshot 1`] = `
+<section
+  className="ContentPageSubsectionTemplateOuterContainer"
+>
+  <h3
+    className="ContentPageSubsectionTitle"
+  >
+    Stage 3
+  </h3>
+  <div>
+    <p
+      className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+    >
+      Stage three begins at the age 18 to 22 months when the cubs have grown to sub-adults and leave their mother. The sub-adults will remain together for up to six more months. At first, their success rate at capturing prey is poor.
+    </p>
+    <p
+      className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+    >
+      Cheetahs are diurnal, hunting mornings and early evenings. They rely on their sight to find prey. They spend most of the day resting under shady trees or on termite mounds. Night hunting is only done during a bright moon.
+    </p>
+    <div>
+      <a
+        href="https://www.nationalgeographic.co.uk/animals/2017/12/stunning-pictures-cheetahs-action"
+      >
+        <button
+          className="ui blue icon button"
+          onClick={[Function]}
+        >
+          Stunning Pictures of Cheetahs in Action | National Geographic
+          <i
+            aria-hidden="true"
+            className="file image icon"
+            onClick={[Function]}
+          />
+        </button>
+      </a>
+    </div>
+    <img
+      alt="What is diurnal?"
+      className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerSmallDimension"
+      src="What_is_Diurnal_L-min.png"
+    />
+  </div>
+</section>
+`;

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_SpotsAndStripes.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_SpotsAndStripes.test.js.snap
@@ -1,0 +1,456 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BiologyPageSubsectionSpotsAndStripes component snapshot 1`] = `
+<section
+  className="ContentPageSubsectionTemplateOuterContainer"
+>
+  <h3
+    className="ContentPageSubsectionTitle"
+  >
+    Spots and Stripes
+  </h3>
+  <div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Adult cheetahs are easily distinguished from other cats by their coat patterns. The color and spots are a form of camouflage. This helps cheetahs hunt prey and hide from other predators.
+      </p>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Distinctive black tear stripes run from the eyes to the mouth. The stripes are thought to protect the eyes from the sun’s glare. It is believed they have the same function as a rifle scope, helping cheetahs focus on their prey.
+      </p>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Until three months of age, cheetah cubs have a thick-silvery grey mantle that runs down their back. The mantle helps camouflage the cubs by blending them into the shadows and grass. It also provides protection from sun and rain.
+      </p>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        With their mantle, cubs look like an aggressive animal called a honey badger. This may deter predators such as lions, hyenas, and eagles from attempting to kill them. This is known as “mimicry”.
+      </p>
+      <img
+        alt="What is camouflage?"
+        className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerMediumDimension"
+        src="What_is_Camouflage_L-min.png"
+      />
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <div
+        className="Centered FullWidth"
+        style={
+          Object {
+            "width": 360,
+          }
+        }
+      >
+        <div
+          className="ImageViewOuterContainer"
+          style={
+            Object {
+              "maxWidth": 360,
+            }
+          }
+        >
+          <div
+            className="ImageViewInnerContainer"
+          >
+            <div
+              className="ImageViewImgContainer"
+            >
+              <img
+                alt="Mantle on cheetah cub's back provides a form of camouflage that's critical to its survival."
+                className="ImageViewImg"
+                src="Cheetah_Mantle-min.jpg"
+              />
+            </div>
+            <div
+              className="ImageViewCaptionContainer"
+            >
+              <div
+                className="CaptionContainer"
+                data-testid="CaptionComponentTestId"
+                style={
+                  Object {
+                    "maxWidth": 360,
+                  }
+                }
+              >
+                <div
+                  className="IconContainer"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="image icon"
+                    onClick={[Function]}
+                  />
+                </div>
+                <p
+                  className="ContentPageCaptionTextSize CaptionText"
+                >
+                  Mantle on cheetah cub's back provides a form of camouflage that's critical to its survival.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="VerticalCushionPaddingTopLarge"
+      >
+        <div
+          className="Centered FullWidth"
+          style={
+            Object {
+              "width": 720,
+            }
+          }
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 720,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="The cheetah's mantle also provides a form of “mimicry” that it can use to deter predators."
+                  className="ImageViewImg"
+                  src="cheetah_and_honey_badger_L-min.jpg"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 720,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    The cheetah's mantle also provides a form of “mimicry” that it can use to deter predators.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div
+        className="BigCatSpotsIllustrationPageSubsectionWrapper"
+      >
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <div
+            className="BigCatSpotsIllustrationOuterContainer"
+          >
+            <div>
+              <h4
+                className="IllustrationFontName IllustrationTitleFontSize"
+              >
+                What Cat am I?
+              </h4>
+              <h5
+                className="IllustrationFontName IllustrationSubtitleFontSize"
+              >
+                Identify the cat by looking at coat patterns and colors.
+              </h5>
+              <div
+                className="ui four column grid"
+              >
+                <div
+                  className="row"
+                >
+                  <div
+                    className="column"
+                  >
+                    <div
+                      className="BigCatSpotsIllustrationItemContainer"
+                    >
+                      <div
+                        className="BigCatSpotsIllustrationTextRevealDetailedContainer"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                            }
+                          }
+                        >
+                          <div
+                            className="ui fade reveal"
+                          >
+                            <div
+                              className="ui visible content"
+                            >
+                              <div
+                                className="TextRevealDetailedCoverContainer"
+                              >
+                                <img
+                                  className="ui image"
+                                  src="pelt_spot_tiger-min.jpg"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ui hidden content"
+                            >
+                              <div
+                                className="TextRevealDetailedContentContainer"
+                                style={
+                                  Object {
+                                    "backgroundColor": "green",
+                                  }
+                                }
+                              >
+                                <img
+                                  alt="Tiger"
+                                  src="cat_thumbnail_tiger-min.jpg"
+                                />
+                                <p
+                                  className="TextRevealDetailedCaptionText"
+                                >
+                                  Tiger
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize"
+                      >
+                        I live in well-watered grasslands, scrubs, woodlands, or reed beds.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="column"
+                  >
+                    <div
+                      className="BigCatSpotsIllustrationItemContainer"
+                    >
+                      <div
+                        className="BigCatSpotsIllustrationTextRevealDetailedContainer"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                            }
+                          }
+                        >
+                          <div
+                            className="ui fade reveal"
+                          >
+                            <div
+                              className="ui visible content"
+                            >
+                              <div
+                                className="TextRevealDetailedCoverContainer"
+                              >
+                                <img
+                                  className="ui image"
+                                  src="pelt_spot_jaguar-min.jpg"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ui hidden content"
+                            >
+                              <div
+                                className="TextRevealDetailedContentContainer"
+                                style={
+                                  Object {
+                                    "backgroundColor": "green",
+                                  }
+                                }
+                              >
+                                <img
+                                  alt="Jaguar"
+                                  src="cat_thumbnail_jaguar-min.jpg"
+                                />
+                                <p
+                                  className="TextRevealDetailedCaptionText"
+                                >
+                                  Jaguar
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize"
+                      >
+                        I'm from South America and live in the jungle.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="column"
+                  >
+                    <div
+                      className="BigCatSpotsIllustrationItemContainer"
+                    >
+                      <div
+                        className="BigCatSpotsIllustrationTextRevealDetailedContainer"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                            }
+                          }
+                        >
+                          <div
+                            className="ui fade reveal"
+                          >
+                            <div
+                              className="ui visible content"
+                            >
+                              <div
+                                className="TextRevealDetailedCoverContainer"
+                              >
+                                <img
+                                  className="ui image"
+                                  src="pelt_spot_cheetah-min.jpg"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ui hidden content"
+                            >
+                              <div
+                                className="TextRevealDetailedContentContainer"
+                                style={
+                                  Object {
+                                    "backgroundColor": "green",
+                                  }
+                                }
+                              >
+                                <img
+                                  alt="Cheetah"
+                                  src="cat_thumbnail_cheetah-min.jpg"
+                                />
+                                <p
+                                  className="TextRevealDetailedCaptionText"
+                                >
+                                  Cheetah
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize"
+                      >
+                        I can live anywhere but prefer savannas.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    className="column"
+                  >
+                    <div
+                      className="BigCatSpotsIllustrationItemContainer"
+                    >
+                      <div
+                        className="BigCatSpotsIllustrationTextRevealDetailedContainer"
+                      >
+                        <div
+                          style={
+                            Object {
+                              "position": "absolute",
+                            }
+                          }
+                        >
+                          <div
+                            className="ui fade reveal"
+                          >
+                            <div
+                              className="ui visible content"
+                            >
+                              <div
+                                className="TextRevealDetailedCoverContainer"
+                              >
+                                <img
+                                  className="ui image"
+                                  src="pelt_spot_leopard-min.jpg"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ui hidden content"
+                            >
+                              <div
+                                className="TextRevealDetailedContentContainer"
+                                style={
+                                  Object {
+                                    "backgroundColor": "green",
+                                  }
+                                }
+                              >
+                                <img
+                                  alt="Leopard"
+                                  src="cat_thumbnail_leopard-min.jpg"
+                                />
+                                <p
+                                  className="TextRevealDetailedCaptionText"
+                                >
+                                  Leopard
+                                </p>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize"
+                      >
+                        I can live anywhere that is rich in prey and has thick bush for cover. I'm often seen resting on trees.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
+++ b/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
@@ -40,8 +40,7 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionHuntingAndPredatorControl._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionHuntingAndPredatorControl._SUBSECTION_NAME_]
     };
   }
 
@@ -107,7 +106,8 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   }
 
   renderWhatIsSustainableUtilizationImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage
@@ -154,7 +154,8 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   }
 
   renderWhatIsProblemAnimalImage(matches) {
-    const images = this.state.imagesContext("./assets");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage

--- a/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
+++ b/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
@@ -106,8 +106,8 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   }
 
   renderWhatIsSustainableUtilizationImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <FactBannerImage
@@ -154,8 +154,8 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   }
 
   renderWhatIsProblemAnimalImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <FactBannerImage

--- a/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
+++ b/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -12,6 +12,8 @@ import React from 'react'
 import Media from 'react-media'
 
 import '../shared/ContentPageSharedStyles.css'
+
+import { requireContext } from '../shared/workarounds/RequireContextMock'
 
 import ContentPageSubsectionTemplate from '../shared/ContentPageSubsectionTemplate'
 import ContentPageSubsectionPart from '../shared/ContentPageSubsectionPart'
@@ -38,8 +40,7 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionHuntingAndPredatorControl._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionHuntingAndPredatorControl._SUBSECTION_NAME_]
     };
   }
 
@@ -105,7 +106,8 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   }
 
   renderWhatIsSustainableUtilizationImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage
@@ -152,7 +154,8 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   }
 
   renderWhatIsProblemAnimalImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage

--- a/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
+++ b/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
@@ -40,7 +40,8 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionHuntingAndPredatorControl._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionHuntingAndPredatorControl._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -106,8 +107,7 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   }
 
   renderWhatIsSustainableUtilizationImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <FactBannerImage
@@ -154,8 +154,7 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   }
 
   renderWhatIsProblemAnimalImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets");
 
     return (
       <FactBannerImage

--- a/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,6 +20,8 @@ import ContentPageTwoColumnImageGallary from '../shared/ContentPageTwoColumnImag
 import {
   ContentPageSubsectionParagraphsContentBinder
 } from '../shared/ContentPageSubsectionContentBinder'
+
+import { requireContext } from '../shared/workarounds/RequireContextMock'
 
 import { GetImagePath } from '../shared/Path'
 
@@ -39,8 +41,7 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheCheetahsPrey._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheCheetahsPrey._SUBSECTION_NAME_]
     };
   }
 
@@ -102,7 +103,8 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
   }
 
   renderCheetahLionComparisonImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ContentPageSubsectionPart>

--- a/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
@@ -41,8 +41,7 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheCheetahsPrey._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheCheetahsPrey._SUBSECTION_NAME_]
     };
   }
 
@@ -104,7 +103,8 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
   }
 
   renderCheetahLionComparisonImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ContentPageSubsectionPart>

--- a/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
@@ -41,7 +41,8 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheCheetahsPrey._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheCheetahsPrey._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -103,8 +104,7 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
   }
 
   renderCheetahLionComparisonImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <ContentPageSubsectionPart>

--- a/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
@@ -103,8 +103,8 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
   }
 
   renderCheetahLionComparisonImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <ContentPageSubsectionPart>

--- a/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
@@ -117,8 +117,8 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
   }
 
   renderConservancyImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <ImageView

--- a/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
@@ -40,7 +40,8 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheFarmingCommunity._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheFarmingCommunity._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -117,8 +118,7 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
   }
 
   renderConservancyImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <ImageView

--- a/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -23,6 +23,8 @@ import {
   ContentPageSubsectionParagraphsContentBinder
 } from '../shared/ContentPageSubsectionContentBinder'
 
+import { requireContext } from '../shared/workarounds/RequireContextMock'
+
 import { GetImagePath } from '../shared/Path'
 
 import { kStringConstantCheetahConservationFund } from '../shared/constants'
@@ -38,8 +40,7 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheFarmingCommunity._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheFarmingCommunity._SUBSECTION_NAME_]
     };
   }
 
@@ -116,7 +117,8 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
   }
 
   renderConservancyImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ImageView

--- a/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
@@ -40,8 +40,7 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheFarmingCommunity._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheFarmingCommunity._SUBSECTION_NAME_]
     };
   }
 
@@ -118,7 +117,8 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
   }
 
   renderConservancyImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ImageView

--- a/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
+++ b/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
@@ -155,7 +155,7 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderAfricanSavannaImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
     const images = context();
 
     return (

--- a/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
+++ b/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -23,6 +23,8 @@ import ContentPageSideFloatFluidContainer from '../shared/ContentPageSideFloatFl
 import {
   ContentPageSubsectionParagraphsContentBinder
 } from '../shared/ContentPageSubsectionContentBinder'
+
+import { requireContext } from '../shared/workarounds/RequireContextMock'
 
 import { GetImagePath } from '../shared/Path'
 
@@ -58,8 +60,7 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionWhereCheetahsLive._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionWhereCheetahsLive._SUBSECTION_NAME_]
     };
   }
 
@@ -125,7 +126,8 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderWhatIsHabitatImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage
@@ -153,7 +155,8 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderAfricanSavannaImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FluidImageWrapper
@@ -187,21 +190,32 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
           </CenteredFullWidthContainer>
         </div>
 
-        <Media queries={{
-          small: "(max-width: 480px)",
-        }}>
-          {
-            matches => (this.renderWhatIsBiomeImage(matches))
-          }
-        </Media>
+        {this.renderWhatIsBiomeImagePart()}
 
         {this.renderImageViewModals()}
       </ContentPageSubsectionPart>
     );
   }
 
+  renderWhatIsBiomeImagePart() {
+    if (__TEST__) {
+      return this.renderWhatIsBiomeImage(null);
+    }
+
+    return (
+      <Media queries={{
+        small: "(max-width: 480px)",
+      }}>
+        {
+          matches => (this.renderWhatIsBiomeImage(matches))
+        }
+      </Media>
+    );
+  }
+
   renderWhatIsBiomeImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage

--- a/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
+++ b/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
@@ -126,8 +126,8 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderWhatIsHabitatImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <FactBannerImage
@@ -156,7 +156,7 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
 
   renderAfricanSavannaImage(matches) {
     const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = context();
 
     return (
       <FluidImageWrapper
@@ -214,8 +214,8 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderWhatIsBiomeImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <FactBannerImage

--- a/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
+++ b/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
@@ -60,7 +60,8 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionWhereCheetahsLive._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionWhereCheetahsLive._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -126,8 +127,7 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderWhatIsHabitatImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <FactBannerImage
@@ -155,8 +155,7 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderAfricanSavannaImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <FluidImageWrapper
@@ -214,8 +213,7 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderWhatIsBiomeImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <FactBannerImage

--- a/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
+++ b/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
@@ -60,8 +60,7 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionWhereCheetahsLive._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionWhereCheetahsLive._SUBSECTION_NAME_]
     };
   }
 
@@ -127,7 +126,8 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderWhatIsHabitatImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage
@@ -155,7 +155,8 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderAfricanSavannaImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FluidImageWrapper
@@ -213,7 +214,8 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   }
 
   renderWhatIsBiomeImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FactBannerImage

--- a/src/components/ecology/__tests__/EcologyPage_Section_Ecomanagement.test.js
+++ b/src/components/ecology/__tests__/EcologyPage_Section_Ecomanagement.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -18,27 +18,19 @@ import renderer from 'react-test-renderer'
 import EcologyPageSectionEcomanagement from '../EcologyPage_Section_Ecomanagement'
 
 test('renders EcologyPageSectionEcomanagement component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <EcologyPageSectionEcomanagement
-  //     config={config}
-  //   />
-  // );
+  render(
+    <EcologyPageSectionEcomanagement
+      config={config}
+    />
+  );
 });
 
 test('EcologyPageSectionEcomanagement component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <EcologyPageSectionEcomanagement
-  //       config={config}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <EcologyPageSectionEcomanagement
+        config={config}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/ecology/__tests__/EcologyPage_Section_EcosystemAndHabitat.test.js
+++ b/src/components/ecology/__tests__/EcologyPage_Section_EcosystemAndHabitat.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -18,27 +18,19 @@ import renderer from 'react-test-renderer'
 import EcologyPageSectionEcosystemAndHabitat from '../EcologyPage_Section_EcosystemAndHabitat'
 
 test('renders EcologyPageSectionEcosystemAndHabitat component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <EcologyPageSectionEcosystemAndHabitat
-  //     config={config}
-  //   />
-  // );
+  render(
+    <EcologyPageSectionEcosystemAndHabitat
+      config={config}
+    />
+  );
 });
 
 test('EcologyPageSectionEcosystemAndHabitat component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <EcologyPageSectionEcosystemAndHabitat
-  //       config={config}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <EcologyPageSectionEcosystemAndHabitat
+        config={config}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/ecology/__tests__/EcologyPage_Subsection_CheetahFriendlyFarming.test.js
+++ b/src/components/ecology/__tests__/EcologyPage_Subsection_CheetahFriendlyFarming.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 21, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import EcologyPageSubsectionCheetahFriendlyFarming from '../EcologyPage_Subsecti
 const sectionConfig = config.contentPageSections["section_Ecomanagement"];
 
 test('renders EcologyPageSubsectionCheetahFriendlyFarming component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <EcologyPageSubsectionCheetahFriendlyFarming
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <EcologyPageSubsectionCheetahFriendlyFarming
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('EcologyPageSubsectionCheetahFriendlyFarming component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <EcologyPageSubsectionCheetahFriendlyFarming
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <EcologyPageSubsectionCheetahFriendlyFarming
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/ecology/__tests__/EcologyPage_Subsection_HuntingAndPredatorControl.test.js
+++ b/src/components/ecology/__tests__/EcologyPage_Subsection_HuntingAndPredatorControl.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import EcologyPageSubsectionHuntingAndPredatorControl from '../EcologyPage_Subse
 const sectionConfig = config.contentPageSections["section_Ecomanagement"];
 
 test('renders EcologyPageSubsectionHuntingAndPredatorControl component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <EcologyPageSubsectionHuntingAndPredatorControl
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <EcologyPageSubsectionHuntingAndPredatorControl
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('EcologyPageSubsectionHuntingAndPredatorControl component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <EcologyPageSubsectionHuntingAndPredatorControl
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <EcologyPageSubsectionHuntingAndPredatorControl
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/ecology/__tests__/EcologyPage_Subsection_TheCheetahsPrey.test.js
+++ b/src/components/ecology/__tests__/EcologyPage_Subsection_TheCheetahsPrey.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import EcologyPageSubsectionTheCheetahsPrey from '../EcologyPage_Subsection_TheC
 const sectionConfig = config.contentPageSections["section_EcosystemAndHabitat"];
 
 test('renders EcologyPageSubsectionTheCheetahsPrey component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <EcologyPageSubsectionTheCheetahsPrey
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <EcologyPageSubsectionTheCheetahsPrey
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('EcologyPageSubsectionTheCheetahsPrey component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <EcologyPageSubsectionTheCheetahsPrey
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <EcologyPageSubsectionTheCheetahsPrey
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/ecology/__tests__/EcologyPage_Subsection_TheFarmingCommunity.test.js
+++ b/src/components/ecology/__tests__/EcologyPage_Subsection_TheFarmingCommunity.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import EcologyPageSubsectionTheFarmingCommunity from '../EcologyPage_Subsection_
 const sectionConfig = config.contentPageSections["section_Ecomanagement"];
 
 test('renders EcologyPageSubsectionTheFarmingCommunity component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <EcologyPageSubsectionTheFarmingCommunity
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <EcologyPageSubsectionTheFarmingCommunity
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('EcologyPageSubsectionTheFarmingCommunity component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <EcologyPageSubsectionTheFarmingCommunity
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <EcologyPageSubsectionTheFarmingCommunity
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/ecology/__tests__/EcologyPage_Subsection_WhereCheetahsLive.test.js
+++ b/src/components/ecology/__tests__/EcologyPage_Subsection_WhereCheetahsLive.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import EcologyPageSubsectionWhereCheetahsLive from '../EcologyPage_Subsection_Wh
 const sectionConfig = config.contentPageSections["section_EcosystemAndHabitat"];
 
 test('renders EcologyPageSubsectionWhereCheetahsLive component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <EcologyPageSubsectionWhereCheetahsLive
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <EcologyPageSubsectionWhereCheetahsLive
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('EcologyPageSubsectionWhereCheetahsLive component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <EcologyPageSubsectionWhereCheetahsLive
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <EcologyPageSubsectionWhereCheetahsLive
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_Ecomanagement.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_Ecomanagement.test.js.snap
@@ -1,0 +1,960 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EcologyPageSectionEcomanagement component snapshot 1`] = `
+<article
+  className="ContentPageSectionTemplateOuterContainer"
+>
+  <h2
+    className="ContentPageSectionHeadTitle"
+    id="eco-management"
+  >
+    Eco-management
+  </h2>
+  <p
+    className="ContentPageHeadAndSectionIntroText"
+  >
+    Effective management of land, livestock, and wildlife are essential ingredients that lead to sustainable utilizations of resources, more sustainable human developments, as well as better conservation of wildlife and the entire ecosystem. Effective farming practices can yield maximal profits and minimal degradations to the land and nature. Conservancies empower farmers with more well-managed ownership of lands, and can generate income through other revenues such as eco-tourism.
+  </p>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Hunting and Predator Control
+    </h3>
+    <div>
+      <div>
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <h4
+            className="ContentPageSubsectionSubtitle"
+          >
+            Traditional Hunting versus Poaching?
+          </h4>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Subsistence hunting for food is carried out throughout the world where families live off the land. Traditional methods of traps and snares are still popular but more and more people are turning toward guns.
+          </p>
+        </div>
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <h4
+            className="ContentPageSubsectionSubtitle"
+          >
+            Conservation Through Sustainable Utilization
+          </h4>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Sustainability refers to a process that can last forever. Utilizing a resource sustainably means that using the natural resource will not destroy it. Hunting can be a form of sustainable use. A sustainable outlook on hunting also sets aside a portion of the revenue collected from the hunt to support conservation efforts for the species.
+          </p>
+          <img
+            alt="What is sustainable utilization?"
+            className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerMediumDimension"
+            src="What_is_Sustainable_Utilization_L-min.png"
+          />
+        </div>
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <h4
+            className="ContentPageSubsectionSubtitle"
+          >
+            Hunting
+          </h4>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Hunting has changed through the ages from a necessity for survival, to a sport and a management activity. Ethical hunters and trophy hunting operations operate with the best intentions for conservation and the continued existence of the population being hunted.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            In Namibia, there are a number of laws that regulate hunting. Permits are required to hunt wildlife that has been divided up into numerous categories, namely, hunt-able game. With each of these categories there are differing requirements for permits.
+          </p>
+        </div>
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <h4
+            className="ContentPageSubsectionSubtitle"
+          >
+            Population Control
+          </h4>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Game farmers have to manage their herds throughout the year and on occasion they cull animals to reduce their numbers, through shooting or live sale. When animals are shot, the meat is sold for food. Game capture units transport and sell live game. Permits are required for these operations.
+          </p>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Predator Control
+        </h4>
+        <div
+          className="ContentPageSideFloatFluidContainerOuterContainer"
+        >
+          <div
+            className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+          >
+            <div
+              className="TextBubbleOuterContainerFlexWrapper"
+            >
+              <div
+                className="TextBubbleOuterContainer"
+                style={
+                  Object {
+                    "backgroundColor": "rgb(255,155,0)",
+                    "maxWidth": 560,
+                    "minHeight": 560,
+                  }
+                }
+              >
+                <div
+                  className="TextBubbleInnerContainer"
+                >
+                  <div
+                    className="TextBubbleInnerCore"
+                  >
+                    <h1
+                      style={
+                        Object {
+                          "color": "rgb(undefined)",
+                          "fontSize": 44.800000000000004,
+                        }
+                      }
+                    >
+                      Predator control is an issue around the globe.
+                    </h1>
+                    <p
+                      style={
+                        Object {
+                          "color": "rgb(undefined)",
+                          "fontSize": 21,
+                        }
+                      }
+                    >
+                      Proven farm and livestock management techniques can be employed to deter predations from problem animals. One great example is CCF’s Livestock Guarding Dog program.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ContentPageSideFloatFluidContainerFixedPartContainer"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Predator control is an issue around the globe.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              An animal usually resorts to killing livestock due to a medical problem, human influence or a natural incident which renders it unable to catch its wild prey. Only a cheetah that consistently hunts livestock should be considered a problem animal. It is critical to identify the individual culprit causing losses rather than remove all cheetahs indiscriminately. The opportunistic killing of inadequately protected livestock, such a new born calves in the bush, indicates poor livestock management which does not warrant the removal of the predator. Some farmers trap, poison and shoot cheetahs. This may not be due to livestock losses, but simply because the predator entered the farm and is perceived as a threat to livestock or family.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Predator control most commonly involves setting live capture cage traps. Farmers also use gin traps and poisoned carcasses. These methods only increase problems as they tend to lure and kill indiscriminately. Animals suffering as a result include ones which benefit the farmland ecosystem, as such pangolin, aardwolf, honey badger and bat eared fox.
+            </p>
+          </div>
+        </div>
+        <img
+          alt="What is a problem animal?"
+          className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerMediumDimension"
+          src="What_is_a_Problem_Animal_L-min.png"
+        />
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      The Farming Community
+    </h3>
+    <div>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        New methods of livestock and wildlife management are incorporated into agricultural practices to ensure a healthy ecosystem.
+      </p>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Mixed Farming - Wildlife and Livestock
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Combining game and livestock farming holds many advantages for the farmer. A variety of game species helps to maintain a healthy farmland ecosystem by using all levels and forms of vegetation. When livestock prices are low, game animals can supplement the farmer’s income in the form of hunting, ecotourism or direct live sale. Game animals tolerate drought conditions better than livestock. They also act as a buffer reducing the occurrences of predation on livestock.
+        </p>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Conservancies
+        </h4>
+        <div
+          className="ContentPageSideFloatFluidContainerOuterContainer"
+        >
+          <div
+            className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+          >
+            <div
+              className="ImageViewOuterContainer"
+              style={
+                Object {
+                  "maxWidth": 600,
+                }
+              }
+            >
+              <div
+                className="ImageViewInnerContainer"
+              >
+                <div
+                  className="ImageViewImgContainer"
+                >
+                  <img
+                    alt="Cheetah Conservation Fund works with communal farmers and people living around the Greater Waterberg Landscape Conservancy."
+                    className="ImageViewImg"
+                    src="CCF_GWL_map_L-min.jpg"
+                  />
+                </div>
+                <div
+                  className="ImageViewCaptionContainer"
+                >
+                  <div
+                    className="CaptionContainer"
+                    data-testid="CaptionComponentTestId"
+                    style={
+                      Object {
+                        "maxWidth": 600,
+                      }
+                    }
+                  >
+                    <div
+                      className="IconContainer"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="image icon"
+                        onClick={[Function]}
+                      />
+                    </div>
+                    <p
+                      className="ContentPageCaptionTextSize CaptionText"
+                    >
+                      Cheetah Conservation Fund works with communal farmers and people living around the Greater Waterberg Landscape Conservancy. (Image credit: Cheetah Conservation Fund)
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ContentPageSideFloatFluidContainerFixedPartContainer"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Conservancies are legally protected areas with shared common resources where conservation is actively practiced. Its purpose is to achieve a collective policy for the ownership, management and use of resources. Conservation is the management of human use of organisms or ecosystems to ensure that such use is sustainable. Conservancy objectives include the protection, maintenance, rehabilitation, restoration, and enhancement of ecosystems.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Conservancies retain all income from wildlife and tourism based enterprises within the conservancy and decides on how these fund are spent. Commercial conservancies consist of adjacent private farms joining together in common units. Communal conservancies operate on a local level and membership is made up entirely of community members who decide to work together for the sustainable management and use of wildlife and tourism.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Eco-tourism
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Namibia has a reputation as the “Cheetah Capital of the World” and tourists come to see cheetah habitat and learn how cheetahs survive on farmland. Ecotourism focuses in animals, habitats, and places of conservation interest. Etosha National Park, the Namibia Desert and the Skeleton Coast are major attractions for foreign ecotourists. Lodges, guest farms, and commercial villages are points on Namibian ecotours. Many of these destinations promote cheetah conservation.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Sometime in the 2000s, the annual number of tourists visiting Namibia exceeded 500,000. Tourists spend money on transport, lodging, food and souvenirs. This is an important part of the economy and a supplement to agricultural income for many Namibians.
+        </p>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Cheetah Friendly Farming
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Namibian farmers practice diverse farming activities that form part of the ecosystem. It is farmers, hunters, and game managers who will preserve Namibia’s precious ecosystem for future generations to enjoy.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          There is no single solution to predator conflicts. Effective predator control and overall farm management requires a variety of integrated management strategies.
+        </p>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="ContentPageSubsectionThreeColumnContentTemplateOuterContainer"
+        >
+          <div
+            className="ContentPageSubsectionThreeColumnContentTemplateInnerContainer"
+          >
+            <div
+              className="ContentPageSubsectionThreeColumnContentTemplateColumn ContentPageSubsectionThreeColumnContentTemplateLeftColumnContainer"
+            >
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Smallstock practices
+              </h4>
+              <div>
+                <div>
+                  <div
+                    className="VerticalCushionPadding"
+                  >
+                    <h5
+                      className="ContentPageSubsectionSubtitleSecondary"
+                    >
+                      Kraals
+                    </h5>
+                    <p
+                      className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                    >
+                      Kraaling smallstock at night enables monitoring and protection. Sturdy fencing or thorn branches must be tall enough to keep stock in and predators out.
+                    </p>
+                  </div>
+                  <div
+                    className="VerticalCushionPadding"
+                  >
+                    <h5
+                      className="ContentPageSubsectionSubtitleSecondary"
+                    >
+                      Herder
+                    </h5>
+                    <p
+                      className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                    >
+                      Keeping a herder with smallstock during the day provides additional protection.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ContentPageSubsectionThreeColumnContentTemplateColumn ContentPageSubsectionThreeColumnContentTemplateMiddleColumnContainer"
+              style={
+                Object {
+                  "backgroundColor": "rgb(247,220,111)",
+                }
+              }
+            >
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Shared practices
+              </h4>
+              <div>
+                <div>
+                  <div
+                    className="FluidSingleRowGridOuterContainer"
+                    style={
+                      Object {
+                        "justifyContent": undefined,
+                      }
+                    }
+                  >
+                    <img
+                      alt="sheep"
+                      className="FlexClipartSheep"
+                      src="goat_clipart-min.png"
+                      width={160}
+                    />
+                    <img
+                      alt="cattle"
+                      className="FlexClipartCattle"
+                      src="cattle_clipart-min.png"
+                      width={160}
+                    />
+                  </div>
+                  <div>
+                    <div
+                      className="VerticalCushionPadding"
+                    >
+                      <h5
+                        className="ContentPageSubsectionSubtitleSecondary"
+                      >
+                        Herd Management
+                      </h5>
+                      <p
+                        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                      >
+                        Predators such as cheetahs are opportunistic. Management strategies should aim to protect livestock when they are most vulnerable, particularly at night and during birthing seasons. Culling animals that fail to produce or consistently lose calves to predation increases herd production.
+                      </p>
+                    </div>
+                    <div
+                      className="VerticalCushionPadding"
+                    >
+                      <h5
+                        className="ContentPageSubsectionSubtitleSecondary"
+                      >
+                        Seasonal births
+                      </h5>
+                      <p
+                        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                      >
+                        Seasonal birthing allows intensive monitoring of the calving/lambing herds.
+                      </p>
+                      <p
+                        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                      >
+                        Synchronizing livestock births with wildlife calving seasons ensures sufficient natural prey when livestock are most vulnerable.
+                      </p>
+                    </div>
+                    <div
+                      className="VerticalCushionPadding"
+                    >
+                      <h5
+                        className="ContentPageSubsectionSubtitleSecondary"
+                      >
+                        Fencing
+                      </h5>
+                      <p
+                        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                      >
+                        Wildlife-friendly farmers use four to five strands of non-barbed galvanized wires for interior livestock fencing. These low fences are not high and leave a large gap along the bottom to allow migration of wildlife through farmlands.
+                      </p>
+                    </div>
+                    <div
+                      className="VerticalCushionPadding"
+                    >
+                      <h5
+                        className="ContentPageSubsectionSubtitleSecondary"
+                      >
+                        Guard animals
+                      </h5>
+                      <p
+                        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                      >
+                        Losses are reduced by utilizing livestock guardians such as dogs for smallstock and donkeys for cattle. Guard animals need to be healthy and properly trained in order to be effective.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ContentPageSubsectionThreeColumnContentTemplateColumn ContentPageSubsectionThreeColumnContentTemplateRightColumnContainer"
+            >
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Cattle practices
+              </h4>
+              <div>
+                <div>
+                  <div
+                    className="VerticalCushionPadding"
+                  >
+                    <h5
+                      className="ContentPageSubsectionSubtitleSecondary"
+                    >
+                      Calving camps
+                    </h5>
+                    <p
+                      className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                    >
+                      Close monitoring is made possible by locating calving camps near the homestead. This reduces losses to predation, accidents or other complications in the first few weeks of a calf’s life. Larger herd size also discourages predators.
+                    </p>
+                    <p
+                      className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                    >
+                      Calves under three months of age and heifers (first-time mothers) are most vulnerable to predators. Closer monitoring will reduce losses.
+                    </p>
+                  </div>
+                  <div
+                    className="VerticalCushionPadding"
+                  >
+                    <h5
+                      className="ContentPageSubsectionSubtitleSecondary"
+                    >
+                      Breeds
+                    </h5>
+                    <p
+                      className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                    >
+                      Choose breeds that are more aggressive and allowing horns to grow on cows reduces losses to predators.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Bush Encroachment and Solutions
+    </h3>
+    <div>
+      <div>
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <h4
+            className="ContentPageSubsectionSubtitle"
+          >
+            Bush Encroachment
+          </h4>
+          <div
+            className="ContentPageSideFloatFluidContainerOuterContainer"
+          >
+            <div
+              className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+            >
+              <div
+                className="ImageViewOuterContainer"
+                style={
+                  Object {
+                    "maxWidth": 600,
+                  }
+                }
+              >
+                <div
+                  className="ImageViewInnerContainer"
+                >
+                  <div
+                    className="ImageViewImgContainer"
+                  >
+                    <img
+                      alt="Thickened thorn bush degrades entire habitat and poses problems for all species of animals in that habitat."
+                      className="ImageViewImg"
+                      src="bush_encroachment-min.jpg"
+                    />
+                  </div>
+                  <div
+                    className="ImageViewCaptionContainer"
+                  >
+                    <div
+                      className="CaptionContainer"
+                      data-testid="CaptionComponentTestId"
+                      style={
+                        Object {
+                          "maxWidth": 600,
+                        }
+                      }
+                    >
+                      <div
+                        className="IconContainer"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="image icon"
+                          onClick={[Function]}
+                        />
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize CaptionText"
+                      >
+                        Thickened thorn bush degrades entire habitat and poses problems for all species of animals in that habitat. (Image credit: Cheetah Conservation Fund)
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ContentPageSideFloatFluidContainerFixedPartContainer"
+            >
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                One of the most serious environmental threats facing Namibia is bush encroachment. Approximately 14 million hectares of land (12% of Namibia) is now so badly encroached that neither man nor livestock can penetrate it.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Under natural conditions, the savannas are covered with grasslands, scattered trees and shrubs, supporting a wide variety of wildlife. Herbivores usually feed intensely in localized areas for short periods of time. Plants and trees experience brief and intense browsing and grazing pressure separated by extended rest periods. This, combined with regular fires, maintains a balance between trees and grasses. Larger animals like elephant and rhino aid in controlling the growth of bush.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <h4
+            className="ContentPageSubsectionSubtitle"
+          >
+            How does Stock Farming Contribute to Bush Encroachment
+          </h4>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Domestic livestock are primarily grazers. Farm fences prevent livestock from moving freely. If not properly managed, this results in overgrazing. This occurs when animals continue to graze and trampling the land on which they are kept, thus allowing little time for grass species to grow and seed. This leads to the gradual decline of grass species and allows the bush to grow out of control. The prevention of fires adds to bush encroachment.
+          </p>
+        </div>
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <h4
+            className="ContentPageSubsectionSubtitle"
+          >
+            Cheetah Survival in Bush Encroached Areas
+          </h4>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Bush encroachment reduces carrying capacity for both livestock and game species. As bush encroachment increases, cheetahs must adopt their hunting techniques. Ambush tactics may replace the characteristic high-speed chase. Scientists are investigating a possible link between the increased occurrences of cheetah eye injuries and their hunting in bush encroached areas.
+          </p>
+        </div>
+      </div>
+      <div>
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <h4
+            className="ContentPageSubsectionSubtitle"
+          >
+            Bush Encroachment Threatens Cheetah Survival
+          </h4>
+          <div
+            className="ContentPageSideFloatFluidContainerOuterContainer"
+          >
+            <div
+              className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatLeft"
+            >
+              <div
+                className="ImageViewOuterContainer"
+                style={
+                  Object {
+                    "maxWidth": 640,
+                  }
+                }
+              >
+                <div
+                  className="ImageViewInnerContainer"
+                >
+                  <div
+                    className="ImageViewImgContainer"
+                  >
+                    <img
+                      alt="Cheetahs face even more hardship in bush encroached territories. They have to adapt in every aspect of their life, such as hunting."
+                      className="ImageViewImg"
+                      src="Cheetah_Battle_Bush_Encroachment-min.jpg"
+                    />
+                  </div>
+                  <div
+                    className="ImageViewCaptionContainer"
+                  >
+                    <div
+                      className="CaptionContainer"
+                      data-testid="CaptionComponentTestId"
+                      style={
+                        Object {
+                          "maxWidth": 640,
+                        }
+                      }
+                    >
+                      <div
+                        className="IconContainer"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="image icon"
+                          onClick={[Function]}
+                        />
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize CaptionText"
+                      >
+                        Cheetahs face even more hardship in bush encroached territories. They have to adapt in every aspect of their life, such as hunting.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ContentPageSideFloatFluidContainerFixedPartContainer"
+            >
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Cheetahs hunt in open or semi-open savanna using bursts of speed. But Namibia’s livestock farmlands, where 90% of the cheetahs live, are less desirable for the cheetahs and the farmers due to bush encroachment. Bush encroachment, a form of desertification, is caused from overgrazing of livestock on the arid lands and unpredictable and regular droughts.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                The deep rooted thorn bushes reduce the water table and compete with the grasses and become a thicket, taking the underground water and causing desertification. Bush encroachment causes changes in habitats and the mix of prey species on the land.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                The cheetah’s rangeland has been infested with undesirable thickened thorn bush species. Bush encroachment reduces the amount of grasslands and poses a major livelihood threat to Namibians, as well as to the cheetah and other wildlife species.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <h4
+            className="ContentPageSubsectionSubtitle"
+          >
+            Cheetah Conservation Fund’s (CCF) Bush Project
+          </h4>
+          <div
+            className="ContentPageSideFloatFluidContainerOuterContainer"
+          >
+            <div
+              className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+            >
+              <img
+                alt="FSC logo"
+                src="fsc_logo-min.png"
+              />
+            </div>
+            <div
+              className="ContentPageSideFloatFluidContainerFixedPartContainer"
+            >
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                CCF Bush (PTY) LTD, began in 2000, with the support from the United States Agency for International Development (USAID), to study and develop an ecologically and economically viable habitat restoration program. The goal of CCF Bush is to stimulate the development of a Namibian Biomass industry, thereby protecting the bush ecosystem, restoring wildlife habitat, improving farming productivity, creating employment opportunities and providing clean, renewable energy.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                CCF harvests the thickened thorn bush, converting it into a clean-burning, biomass fuel log known as Bushblok ™. CCF has restored hundreds of hectares of savanna grasslands for livestock, wildlife and cheetahs to share. In 2006, CCF obtained Forest Stewardship Council (FSC) certification, confirming that it manages forest resources responsibly and sustainably.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSubsectionPartContainer"
+        >
+          <h4
+            className="ContentPageSubsectionSubtitle"
+          >
+            The Bushblok project objectives are:
+          </h4>
+          <div
+            className="ContentPageSideFloatFluidContainerOuterContainer"
+          >
+            <div
+              className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+            >
+              <img
+                alt="CCF Bushblok"
+                src="CCF_Bushblok_Logo-min.jpg"
+              />
+            </div>
+            <div
+              className="ContentPageSideFloatFluidContainerFixedPartContainer"
+            >
+              <ul>
+                <li
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                >
+                  To enhance the long-term survival of the cheetah and other species by restoring the grasslands.
+                </li>
+                <li
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                >
+                  To provide an alternative to over-exploiting native Namibian trees for firewood and charcoal.
+                </li>
+                <li
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                >
+                  To encourage industries to use intruder bush as a raw material.
+                </li>
+                <li
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                >
+                  To provide standards for bush harvesting, chipping, processing and packaging.
+                </li>
+                <li
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                >
+                  To employ, train and empower disadvantaged Namibians.
+                </li>
+                <li
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                >
+                  To supply Namibians and international markets with compacted fuel log products.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+          >
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+            >
+              <div
+                className="ImageViewOuterContainer"
+                style={
+                  Object {
+                    "maxWidth": 640,
+                  }
+                }
+              >
+                <div
+                  className="ImageViewInnerContainer"
+                >
+                  <div
+                    className="ImageViewImgContainer"
+                  >
+                    <img
+                      alt="Bushblok is produced at CCF from the waste product of habitat restoration."
+                      className="ImageViewImg"
+                      src="CCF_Bushblok_01-min.jpg"
+                    />
+                  </div>
+                  <div
+                    className="ImageViewCaptionContainer"
+                  >
+                    <div
+                      className="CaptionContainer"
+                      data-testid="CaptionComponentTestId"
+                      style={
+                        Object {
+                          "maxWidth": 640,
+                        }
+                      }
+                    >
+                      <div
+                        className="IconContainer"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="image icon"
+                          onClick={[Function]}
+                        />
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize CaptionText"
+                      >
+                        Bushblok is produced at CCF from the waste product of habitat restoration. (Image credit: Cheetah Conservation Fund)
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+            >
+              <div
+                className="ImageViewOuterContainer"
+                style={
+                  Object {
+                    "maxWidth": 640,
+                  }
+                }
+              >
+                <div
+                  className="ImageViewInnerContainer"
+                >
+                  <div
+                    className="ImageViewImgContainer"
+                  >
+                    <img
+                      alt="Bushblok packaging for different markets."
+                      className="ImageViewImg"
+                      src="CCF_Bushblok_02-min.jpg"
+                    />
+                  </div>
+                  <div
+                    className="ImageViewCaptionContainer"
+                  >
+                    <div
+                      className="CaptionContainer"
+                      data-testid="CaptionComponentTestId"
+                      style={
+                        Object {
+                          "maxWidth": 640,
+                        }
+                      }
+                    >
+                      <div
+                        className="IconContainer"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="image icon"
+                          onClick={[Function]}
+                        />
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize CaptionText"
+                      >
+                        Bushblok packaging for different markets. (Image credit: Cheetah Conservation Fund)
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</article>
+`;

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_EcosystemAndHabitat.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_EcosystemAndHabitat.test.js.snap
@@ -1,0 +1,815 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EcologyPageSectionEcosystemAndHabitat component snapshot 1`] = `
+<article
+  className="ContentPageSectionTemplateOuterContainer"
+>
+  <h2
+    className="ContentPageSectionHeadTitle"
+    id="ecosystem-and-habitat"
+  >
+    Ecosystem and Habitat
+  </h2>
+  <p
+    className="ContentPageHeadAndSectionIntroText"
+  >
+    Understanding the relationships and interactions of elements in the ecosystem and habitat where cheetahs live is crucial for any conservation and management efforts. Understanding of subjects in this area can help answer questions such as “what animals do cheetahs prey on and eat” and “what are its roles in its habitat and relationships with other species of animals”.
+  </p>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Where Cheetahs Live
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Cheetah Habitat
+        </h4>
+        <div
+          className="ContentPageSideFloatFluidContainerOuterContainer"
+        >
+          <div
+            className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+          >
+            <div
+              className="ImageViewOuterContainer"
+              style={
+                Object {
+                  "maxWidth": 598,
+                }
+              }
+            >
+              <div
+                className="ImageViewInnerContainer"
+              >
+                <div
+                  className="ImageViewImgContainer"
+                >
+                  <img
+                    alt="African savannas have rich fauna biodiversity and house the habitats of a wide range of wildlife."
+                    className="ImageViewImg"
+                    src="savanna-min.jpg"
+                  />
+                </div>
+                <div
+                  className="ImageViewCaptionContainer"
+                >
+                  <div
+                    className="CaptionContainer"
+                    data-testid="CaptionComponentTestId"
+                    style={
+                      Object {
+                        "maxWidth": 598,
+                      }
+                    }
+                  >
+                    <div
+                      className="IconContainer"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="image icon"
+                        onClick={[Function]}
+                      />
+                    </div>
+                    <p
+                      className="ContentPageCaptionTextSize CaptionText"
+                    >
+                      African savannas have rich fauna biodiversity and house the habitats of a wide range of wildlife.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ContentPageSideFloatFluidContainerFixedPartContainer"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Animals, includes cheetah, are adapted to live in specific habitats. Cheetahs live mainly in grassland savanna. They prefer habitat which includes some cover in the form of bushes, medium length grass, trees, and small hills. Cheetahs need abundant prey in their habitat to survive and reproduce. In Namibia their habitat is densely bushed due to bush encroachment.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Cheetahs sometimes live in a wide variety of habitats. They occasionally use semi-desert, dense woodland or mountainous terrain. Older animals unable to defend territories and young cheetahs just starting to live on their own use these marginal habitats.
+            </p>
+          </div>
+        </div>
+        <img
+          alt="What is a habitat"
+          className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerSmallDimension"
+          src="What_is_Habitat_L-min.png"
+        />
+        <img
+          alt="African savanna"
+          className="FullWidth DisplayBlock RetainAspectRatio Centered"
+          src="savana_bg_large_L-min.jpg"
+        />
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Namibian Biomes
+        </h4>
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+          >
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+            >
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Namibia is a country with rich biodiversity, as its land spans over five distinct types of biomes.
+              </p>
+            </div>
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+            >
+              <div
+                className="ImageSlideModalCoverTriggerOuterContainer"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                style={
+                  Object {
+                    "width": 480,
+                  }
+                }
+              >
+                <div
+                  className="ImageSlideModalCoverTriggerInnerContainer"
+                  data-testid="ImageSlideModalComponentCoverImageContainerDivTestId"
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "backgroundImage": "url(biome_savanna-min.jpg)",
+                      "height": 320,
+                      "width": 480,
+                    }
+                  }
+                >
+                  <div
+                    className="ImageSlideModalCoverTriggerImageIconInnerContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="blue images outline huge icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                </div>
+                <p
+                  className="ContentPageCaptionTextSize"
+                >
+                  Click to learn more about the biomes of Namibia.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="VerticalCushionPaddingTopLarge"
+        >
+          <div
+            className="Centered FullWidth"
+            style={
+              Object {
+                "width": 1200,
+              }
+            }
+          >
+            <div
+              className="ImageViewOuterContainer"
+              style={
+                Object {
+                  "maxWidth": 1200,
+                }
+              }
+            >
+              <div
+                className="ImageViewInnerContainer"
+              >
+                <div
+                  className="ImageViewImgContainer"
+                >
+                  <img
+                    alt="Map of Namibian biomes and cheetah ranges in Namibia. Cheetahs prefer the savanna biome which supports the animals they prey on."
+                    className="ImageViewImg"
+                    src="Namibia_Biomes_and_Cheetah_Ranges_Map-min.jpg"
+                  />
+                </div>
+                <div
+                  className="ImageViewCaptionContainer"
+                >
+                  <div
+                    className="CaptionContainer"
+                    data-testid="CaptionComponentTestId"
+                    style={
+                      Object {
+                        "maxWidth": 1200,
+                      }
+                    }
+                  >
+                    <div
+                      className="IconContainer"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="image icon"
+                        onClick={[Function]}
+                      />
+                    </div>
+                    <p
+                      className="ContentPageCaptionTextSize CaptionText"
+                    >
+                      Map of Namibian biomes and cheetah ranges in Namibia. Cheetahs prefer the savanna biome which supports the animals they prey on.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <img
+          alt="What is biome?"
+          className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerMediumDimension"
+          src="What_is_Biome_L-min.png"
+        />
+        <div
+          className="FluidSingleRowGridOuterContainer"
+          style={
+            Object {
+              "justifyContent": "space-evenly",
+            }
+          }
+        >
+          <div
+            className="ImageViewModalCoverTriggerOuterContainer"
+            data-testid="ImageViewModalComponentCoverImageContainerTestId"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "backgroundImage": "url(namibia_landscape_01-min.jpg)",
+                "height": 320,
+                "width": 480,
+              }
+            }
+          >
+            <div
+              className="ImageViewModalCoverTriggerImageIconInnerContainer"
+            >
+              <i
+                aria-hidden="true"
+                className="black file image large icon"
+                onClick={[Function]}
+              />
+            </div>
+          </div>
+          <div
+            className="ImageViewModalCoverTriggerOuterContainer"
+            data-testid="ImageViewModalComponentCoverImageContainerTestId"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "backgroundImage": "url(namibia_landscape_02-min.jpg)",
+                "height": 320,
+                "width": 480,
+              }
+            }
+          >
+            <div
+              className="ImageViewModalCoverTriggerImageIconInnerContainer"
+            >
+              <i
+                aria-hidden="true"
+                className="black file image large icon"
+                onClick={[Function]}
+              />
+            </div>
+          </div>
+          <div
+            className="ImageViewModalCoverTriggerOuterContainer"
+            data-testid="ImageViewModalComponentCoverImageContainerTestId"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "backgroundImage": "url(namibia_landscape_03-min.jpg)",
+                "height": 320,
+                "width": 480,
+              }
+            }
+          >
+            <div
+              className="ImageViewModalCoverTriggerImageIconInnerContainer"
+            >
+              <i
+                aria-hidden="true"
+                className="black file image large icon"
+                onClick={[Function]}
+              />
+            </div>
+          </div>
+          <div
+            className="ImageViewModalCoverTriggerOuterContainer"
+            data-testid="ImageViewModalComponentCoverImageContainerTestId"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "backgroundImage": "url(namibia_landscape_04-min.jpg)",
+                "height": 320,
+                "width": 480,
+              }
+            }
+          >
+            <div
+              className="ImageViewModalCoverTriggerImageIconInnerContainer"
+            >
+              <i
+                aria-hidden="true"
+                className="black file image large icon"
+                onClick={[Function]}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      The Cheetah’s Prey
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="OverflowHidden"
+        >
+          <div
+            className="FloatRight"
+          >
+            <div
+              className="TextBubbleOuterContainerFlexWrapper"
+            >
+              <div
+                className="TextBubbleOuterContainer"
+                style={
+                  Object {
+                    "backgroundColor": "rgb(187,143,206)",
+                    "maxWidth": 480,
+                    "minHeight": 480,
+                  }
+                }
+              >
+                <div
+                  className="TextBubbleInnerContainer"
+                >
+                  <div
+                    className="TextBubbleInnerCore"
+                  >
+                    <h1
+                      style={
+                        Object {
+                          "color": "rgb(undefined)",
+                          "fontSize": 38.4,
+                        }
+                      }
+                    >
+                      Cheetahs prefer game to livestock
+                    </h1>
+                    <p
+                      style={
+                        Object {
+                          "color": "rgb(undefined)",
+                          "fontSize": 21,
+                        }
+                      }
+                    >
+                      Cheetahs are born to prey on wild game, and will instinctually go after them. Cheetahs only go after livestock as a last resort when wild game is not available. This makes maintaining healthy ecosystems very important.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Cheetahs hunt mostly small antelope, young of large antelope, warthog, hare and game birds. They may take livestock in exceptional or opportunistic cases.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Cheetahs prefer game to livestock.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            The cheetah’s lightweight build limits the size of prey they catch. Male coalitions can, however, overcome larger prey. Coalitions also stand a better chance at defending their prey against competitors than single cheetahs.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Predators have to work very hard to catch their prey. Cheetahs need to carefully select the animal they are most likely to catch. For this reason cheetahs, like all other predators, target animals that are old, sick, very young, injured, or slow. This allows only the strongest to survive and pass on their genes, thus maintaining a healthier game population.
+          </p>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <img
+          alt="Cheetah and lion have drastically different preys, hunting strategies, and success rates."
+          className="FullWidth DisplayBlock RetainAspectRatio Centered"
+          src="Cheetah_Lion_Hunting_Success_Rate_Comparsion_L-min.png"
+        />
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+          >
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+            >
+              <div
+                className="ImageViewOuterContainer"
+                style={
+                  Object {
+                    "maxWidth": 640,
+                  }
+                }
+              >
+                <div
+                  className="ImageViewInnerContainer"
+                >
+                  <div
+                    className="ImageViewImgContainer"
+                  >
+                    <img
+                      alt="Cheetahs in a coalition need to work together as a team to bring down larger and stronger prey, such as this wildebeest."
+                      className="ImageViewImg"
+                      src="cheetah_coalition_hunting-min.jpg"
+                    />
+                  </div>
+                  <div
+                    className="ImageViewCaptionContainer"
+                  >
+                    <div
+                      className="CaptionContainer"
+                      data-testid="CaptionComponentTestId"
+                      style={
+                        Object {
+                          "maxWidth": 640,
+                        }
+                      }
+                    >
+                      <div
+                        className="IconContainer"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="image icon"
+                          onClick={[Function]}
+                        />
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize CaptionText"
+                      >
+                        Cheetahs in a coalition need to work together as a team to bring down larger and stronger prey, such as this wildebeest.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+            >
+              <div
+                className="ImageViewOuterContainer"
+                style={
+                  Object {
+                    "maxWidth": 640,
+                  }
+                }
+              >
+                <div
+                  className="ImageViewInnerContainer"
+                >
+                  <div
+                    className="ImageViewImgContainer"
+                  >
+                    <img
+                      alt="One of cheetahs' favorite type of prey are the gazelles, although they are very vigilant, fast and agile, thus are hard to catch."
+                      className="ImageViewImg"
+                      src="cheetah_go_after_gazelle-min.jpg"
+                    />
+                  </div>
+                  <div
+                    className="ImageViewCaptionContainer"
+                  >
+                    <div
+                      className="CaptionContainer"
+                      data-testid="CaptionComponentTestId"
+                      style={
+                        Object {
+                          "maxWidth": 640,
+                        }
+                      }
+                    >
+                      <div
+                        className="IconContainer"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="image icon"
+                          onClick={[Function]}
+                        />
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize CaptionText"
+                      >
+                        One of cheetahs' favorite type of prey are the gazelles, although they are very vigilant, fast and agile, thus are hard to catch.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Cheetah’s Role in the Ecosystem
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Cheetah’s role
+        </h4>
+        <div
+          className="ContentPageSideFloatFluidContainerOuterContainer"
+        >
+          <div
+            className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+          >
+            <div
+              className="ImageViewOuterContainer"
+              style={
+                Object {
+                  "maxWidth": 640,
+                }
+              }
+            >
+              <div
+                className="ImageViewInnerContainer"
+              >
+                <div
+                  className="ImageViewImgContainer"
+                >
+                  <img
+                    alt="A simplified illustration of the food web of a savanna ecosystem."
+                    className="ImageViewImg"
+                    src="savanna_food_web-min.jpg"
+                  />
+                </div>
+                <div
+                  className="ImageViewCaptionContainer"
+                >
+                  <div
+                    className="CaptionContainer"
+                    data-testid="CaptionComponentTestId"
+                    style={
+                      Object {
+                        "maxWidth": 640,
+                      }
+                    }
+                  >
+                    <div
+                      className="IconContainer"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="image icon"
+                        onClick={[Function]}
+                      />
+                    </div>
+                    <p
+                      className="ContentPageCaptionTextSize CaptionText"
+                    >
+                      A simplified illustration of the food web of a savanna ecosystem.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ContentPageSideFloatFluidContainerFixedPartContainer"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Every animal species has its role (or niche) in the ecosystem that it lives in. As a carnivorous predator, the cheetah’s role in the ecosystem is important as it helps to maintain balanced and healthy food webs.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              One of the cheetah’s roles in the ecosystem is to help keep the population of grazing animals at a healthy state. Because of the fact that cheetahs do not have the strength to go after big games such as adult wildebeest, elands, and kudus, they go after the ones that are young, weak, or sick. This helps to ensure that only the strongest of those species will survive, and also the populations of those species won’t reach the limit the ecosystem could handle such that it will have negative consequences.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Relationships with other species
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Perhaps the cheetahs’ closest interactions with other species of animals other than the ones preyed upon are their competitors. While there are no species of animals that solely prey on the cheetahs as a food source, many compete with the cheetahs for food, territory, and dominance. Lions, leopards, and hyenas are the most formidable competitors that would come into the way of the cheetahs.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Despite the fact that competitions inevitably lead to casualties, it is an important aspect of any healthy ecosystem. Competitions ensure that no species of animal absolutely dominates all the resources in a territory, and resources are partitioned accordingly among the competing species as much as possible to minimize conflict. This leads to a balanced ecosystem with the most biodiversity, as each species is unique in its role within the ecosystem.
+        </p>
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+          >
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+            >
+              <div
+                className="ImageViewOuterContainer"
+                style={
+                  Object {
+                    "maxWidth": 483,
+                  }
+                }
+              >
+                <div
+                  className="ImageViewInnerContainer"
+                >
+                  <div
+                    className="ImageViewImgContainer"
+                  >
+                    <img
+                      alt="Hyenas often try to either steal cheetahs' killed preys or scavenge on the remains."
+                      className="ImageViewImg"
+                      src="cheetah_hyena_competition-min.jpg"
+                    />
+                  </div>
+                  <div
+                    className="ImageViewCaptionContainer"
+                  >
+                    <div
+                      className="CaptionContainer"
+                      data-testid="CaptionComponentTestId"
+                      style={
+                        Object {
+                          "maxWidth": 483,
+                        }
+                      }
+                    >
+                      <div
+                        className="IconContainer"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="image icon"
+                          onClick={[Function]}
+                        />
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize CaptionText"
+                      >
+                        Hyenas often try to either steal cheetahs' killed preys or scavenge on the remains.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+            >
+              <div
+                className="ImageViewOuterContainer"
+                style={
+                  Object {
+                    "maxWidth": 480,
+                  }
+                }
+              >
+                <div
+                  className="ImageViewInnerContainer"
+                >
+                  <div
+                    className="ImageViewImgContainer"
+                  >
+                    <img
+                      alt="Lions will often take over the cheetah's prey easily as they are superior in strength."
+                      className="ImageViewImg"
+                      src="cheetah_lion_competition-min.jpg"
+                    />
+                  </div>
+                  <div
+                    className="ImageViewCaptionContainer"
+                  >
+                    <div
+                      className="CaptionContainer"
+                      data-testid="CaptionComponentTestId"
+                      style={
+                        Object {
+                          "maxWidth": 480,
+                        }
+                      }
+                    >
+                      <div
+                        className="IconContainer"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="image icon"
+                          onClick={[Function]}
+                        />
+                      </div>
+                      <p
+                        className="ContentPageCaptionTextSize CaptionText"
+                      >
+                        Lions will often take over the cheetah's prey easily as they are superior in strength.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</article>
+`;

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_CheetahFriendlyFarming.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_CheetahFriendlyFarming.test.js.snap
@@ -1,0 +1,134 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EcologyPageSubsectionCheetahFriendlyFarming component snapshot 1`] = `
+<section
+  className="ContentPageSubsectionTemplateOuterContainer"
+>
+  <h3
+    className="ContentPageSubsectionTitle"
+  >
+    The Farming Community
+  </h3>
+  <div>
+    <p
+      className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+    >
+      New methods of livestock and wildlife management are incorporated into agricultural practices to ensure a healthy ecosystem.
+    </p>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Mixed Farming - Wildlife and Livestock
+      </h4>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Combining game and livestock farming holds many advantages for the farmer. A variety of game species helps to maintain a healthy farmland ecosystem by using all levels and forms of vegetation. When livestock prices are low, game animals can supplement the farmer’s income in the form of hunting, ecotourism or direct live sale. Game animals tolerate drought conditions better than livestock. They also act as a buffer reducing the occurrences of predation on livestock.
+      </p>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Conservancies
+      </h4>
+      <div
+        className="ContentPageSideFloatFluidContainerOuterContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 600,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="Cheetah Conservation Fund works with communal farmers and people living around the Greater Waterberg Landscape Conservancy."
+                  className="ImageViewImg"
+                  src="CCF_GWL_map_L-min.jpg"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 600,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    Cheetah Conservation Fund works with communal farmers and people living around the Greater Waterberg Landscape Conservancy. (Image credit: Cheetah Conservation Fund)
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSideFloatFluidContainerFixedPartContainer"
+        >
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Conservancies are legally protected areas with shared common resources where conservation is actively practiced. Its purpose is to achieve a collective policy for the ownership, management and use of resources. Conservation is the management of human use of organisms or ecosystems to ensure that such use is sustainable. Conservancy objectives include the protection, maintenance, rehabilitation, restoration, and enhancement of ecosystems.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Conservancies retain all income from wildlife and tourism based enterprises within the conservancy and decides on how these fund are spent. Commercial conservancies consist of adjacent private farms joining together in common units. Communal conservancies operate on a local level and membership is made up entirely of community members who decide to work together for the sustainable management and use of wildlife and tourism.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Eco-tourism
+      </h4>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Namibia has a reputation as the “Cheetah Capital of the World” and tourists come to see cheetah habitat and learn how cheetahs survive on farmland. Ecotourism focuses in animals, habitats, and places of conservation interest. Etosha National Park, the Namibia Desert and the Skeleton Coast are major attractions for foreign ecotourists. Lodges, guest farms, and commercial villages are points on Namibian ecotours. Many of these destinations promote cheetah conservation.
+      </p>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Sometime in the 2000s, the annual number of tourists visiting Namibia exceeded 500,000. Tourists spend money on transport, lodging, food and souvenirs. This is an important part of the economy and a supplement to agricultural income for many Namibians.
+      </p>
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_HuntingAndPredatorControl.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_HuntingAndPredatorControl.test.js.snap
@@ -1,0 +1,167 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EcologyPageSubsectionHuntingAndPredatorControl component snapshot 1`] = `
+<section
+  className="ContentPageSubsectionTemplateOuterContainer"
+>
+  <h3
+    className="ContentPageSubsectionTitle"
+  >
+    Hunting and Predator Control
+  </h3>
+  <div>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Traditional Hunting versus Poaching?
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Subsistence hunting for food is carried out throughout the world where families live off the land. Traditional methods of traps and snares are still popular but more and more people are turning toward guns.
+        </p>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Conservation Through Sustainable Utilization
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Sustainability refers to a process that can last forever. Utilizing a resource sustainably means that using the natural resource will not destroy it. Hunting can be a form of sustainable use. A sustainable outlook on hunting also sets aside a portion of the revenue collected from the hunt to support conservation efforts for the species.
+        </p>
+        <img
+          alt="What is sustainable utilization?"
+          className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerMediumDimension"
+          src="What_is_Sustainable_Utilization_L-min.png"
+        />
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Hunting
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Hunting has changed through the ages from a necessity for survival, to a sport and a management activity. Ethical hunters and trophy hunting operations operate with the best intentions for conservation and the continued existence of the population being hunted.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          In Namibia, there are a number of laws that regulate hunting. Permits are required to hunt wildlife that has been divided up into numerous categories, namely, hunt-able game. With each of these categories there are differing requirements for permits.
+        </p>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Population Control
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Game farmers have to manage their herds throughout the year and on occasion they cull animals to reduce their numbers, through shooting or live sale. When animals are shot, the meat is sold for food. Game capture units transport and sell live game. Permits are required for these operations.
+        </p>
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Predator Control
+      </h4>
+      <div
+        className="ContentPageSideFloatFluidContainerOuterContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+        >
+          <div
+            className="TextBubbleOuterContainerFlexWrapper"
+          >
+            <div
+              className="TextBubbleOuterContainer"
+              style={
+                Object {
+                  "backgroundColor": "rgb(255,155,0)",
+                  "maxWidth": 560,
+                  "minHeight": 560,
+                }
+              }
+            >
+              <div
+                className="TextBubbleInnerContainer"
+              >
+                <div
+                  className="TextBubbleInnerCore"
+                >
+                  <h1
+                    style={
+                      Object {
+                        "color": "rgb(undefined)",
+                        "fontSize": 44.800000000000004,
+                      }
+                    }
+                  >
+                    Predator control is an issue around the globe.
+                  </h1>
+                  <p
+                    style={
+                      Object {
+                        "color": "rgb(undefined)",
+                        "fontSize": 21,
+                      }
+                    }
+                  >
+                    Proven farm and livestock management techniques can be employed to deter predations from problem animals. One great example is CCF’s Livestock Guarding Dog program.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSideFloatFluidContainerFixedPartContainer"
+        >
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Predator control is an issue around the globe.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            An animal usually resorts to killing livestock due to a medical problem, human influence or a natural incident which renders it unable to catch its wild prey. Only a cheetah that consistently hunts livestock should be considered a problem animal. It is critical to identify the individual culprit causing losses rather than remove all cheetahs indiscriminately. The opportunistic killing of inadequately protected livestock, such a new born calves in the bush, indicates poor livestock management which does not warrant the removal of the predator. Some farmers trap, poison and shoot cheetahs. This may not be due to livestock losses, but simply because the predator entered the farm and is perceived as a threat to livestock or family.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Predator control most commonly involves setting live capture cage traps. Farmers also use gin traps and poisoned carcasses. These methods only increase problems as they tend to lure and kill indiscriminately. Animals suffering as a result include ones which benefit the farmland ecosystem, as such pangolin, aardwolf, honey badger and bat eared fox.
+          </p>
+        </div>
+      </div>
+      <img
+        alt="What is a problem animal?"
+        className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerMediumDimension"
+        src="What_is_a_Problem_Animal_L-min.png"
+      />
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_TheCheetahsPrey.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_TheCheetahsPrey.test.js.snap
@@ -1,0 +1,219 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EcologyPageSubsectionTheCheetahsPrey component snapshot 1`] = `
+<section
+  className="ContentPageSubsectionTemplateOuterContainer"
+>
+  <h3
+    className="ContentPageSubsectionTitle"
+  >
+    The Cheetah’s Prey
+  </h3>
+  <div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <div
+        className="OverflowHidden"
+      >
+        <div
+          className="FloatRight"
+        >
+          <div
+            className="TextBubbleOuterContainerFlexWrapper"
+          >
+            <div
+              className="TextBubbleOuterContainer"
+              style={
+                Object {
+                  "backgroundColor": "rgb(187,143,206)",
+                  "maxWidth": 480,
+                  "minHeight": 480,
+                }
+              }
+            >
+              <div
+                className="TextBubbleInnerContainer"
+              >
+                <div
+                  className="TextBubbleInnerCore"
+                >
+                  <h1
+                    style={
+                      Object {
+                        "color": "rgb(undefined)",
+                        "fontSize": 38.4,
+                      }
+                    }
+                  >
+                    Cheetahs prefer game to livestock
+                  </h1>
+                  <p
+                    style={
+                      Object {
+                        "color": "rgb(undefined)",
+                        "fontSize": 21,
+                      }
+                    }
+                  >
+                    Cheetahs are born to prey on wild game, and will instinctually go after them. Cheetahs only go after livestock as a last resort when wild game is not available. This makes maintaining healthy ecosystems very important.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Cheetahs hunt mostly small antelope, young of large antelope, warthog, hare and game birds. They may take livestock in exceptional or opportunistic cases.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Cheetahs prefer game to livestock.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          The cheetah’s lightweight build limits the size of prey they catch. Male coalitions can, however, overcome larger prey. Coalitions also stand a better chance at defending their prey against competitors than single cheetahs.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Predators have to work very hard to catch their prey. Cheetahs need to carefully select the animal they are most likely to catch. For this reason cheetahs, like all other predators, target animals that are old, sick, very young, injured, or slow. This allows only the strongest to survive and pass on their genes, thus maintaining a healthier game population.
+        </p>
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <img
+        alt="Cheetah and lion have drastically different preys, hunting strategies, and success rates."
+        className="FullWidth DisplayBlock RetainAspectRatio Centered"
+        src="Cheetah_Lion_Hunting_Success_Rate_Comparsion_L-min.png"
+      />
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <div
+        className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+      >
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+          >
+            <div
+              className="ImageViewOuterContainer"
+              style={
+                Object {
+                  "maxWidth": 640,
+                }
+              }
+            >
+              <div
+                className="ImageViewInnerContainer"
+              >
+                <div
+                  className="ImageViewImgContainer"
+                >
+                  <img
+                    alt="Cheetahs in a coalition need to work together as a team to bring down larger and stronger prey, such as this wildebeest."
+                    className="ImageViewImg"
+                    src="cheetah_coalition_hunting-min.jpg"
+                  />
+                </div>
+                <div
+                  className="ImageViewCaptionContainer"
+                >
+                  <div
+                    className="CaptionContainer"
+                    data-testid="CaptionComponentTestId"
+                    style={
+                      Object {
+                        "maxWidth": 640,
+                      }
+                    }
+                  >
+                    <div
+                      className="IconContainer"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="image icon"
+                        onClick={[Function]}
+                      />
+                    </div>
+                    <p
+                      className="ContentPageCaptionTextSize CaptionText"
+                    >
+                      Cheetahs in a coalition need to work together as a team to bring down larger and stronger prey, such as this wildebeest.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+          >
+            <div
+              className="ImageViewOuterContainer"
+              style={
+                Object {
+                  "maxWidth": 640,
+                }
+              }
+            >
+              <div
+                className="ImageViewInnerContainer"
+              >
+                <div
+                  className="ImageViewImgContainer"
+                >
+                  <img
+                    alt="One of cheetahs' favorite type of prey are the gazelles, although they are very vigilant, fast and agile, thus are hard to catch."
+                    className="ImageViewImg"
+                    src="cheetah_go_after_gazelle-min.jpg"
+                  />
+                </div>
+                <div
+                  className="ImageViewCaptionContainer"
+                >
+                  <div
+                    className="CaptionContainer"
+                    data-testid="CaptionComponentTestId"
+                    style={
+                      Object {
+                        "maxWidth": 640,
+                      }
+                    }
+                  >
+                    <div
+                      className="IconContainer"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="image icon"
+                        onClick={[Function]}
+                      />
+                    </div>
+                    <p
+                      className="ContentPageCaptionTextSize CaptionText"
+                    >
+                      One of cheetahs' favorite type of prey are the gazelles, although they are very vigilant, fast and agile, thus are hard to catch.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_TheFarmingCommunity.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_TheFarmingCommunity.test.js.snap
@@ -1,0 +1,134 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EcologyPageSubsectionTheFarmingCommunity component snapshot 1`] = `
+<section
+  className="ContentPageSubsectionTemplateOuterContainer"
+>
+  <h3
+    className="ContentPageSubsectionTitle"
+  >
+    The Farming Community
+  </h3>
+  <div>
+    <p
+      className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+    >
+      New methods of livestock and wildlife management are incorporated into agricultural practices to ensure a healthy ecosystem.
+    </p>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Mixed Farming - Wildlife and Livestock
+      </h4>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Combining game and livestock farming holds many advantages for the farmer. A variety of game species helps to maintain a healthy farmland ecosystem by using all levels and forms of vegetation. When livestock prices are low, game animals can supplement the farmer’s income in the form of hunting, ecotourism or direct live sale. Game animals tolerate drought conditions better than livestock. They also act as a buffer reducing the occurrences of predation on livestock.
+      </p>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Conservancies
+      </h4>
+      <div
+        className="ContentPageSideFloatFluidContainerOuterContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 600,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="Cheetah Conservation Fund works with communal farmers and people living around the Greater Waterberg Landscape Conservancy."
+                  className="ImageViewImg"
+                  src="CCF_GWL_map_L-min.jpg"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 600,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    Cheetah Conservation Fund works with communal farmers and people living around the Greater Waterberg Landscape Conservancy. (Image credit: Cheetah Conservation Fund)
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSideFloatFluidContainerFixedPartContainer"
+        >
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Conservancies are legally protected areas with shared common resources where conservation is actively practiced. Its purpose is to achieve a collective policy for the ownership, management and use of resources. Conservation is the management of human use of organisms or ecosystems to ensure that such use is sustainable. Conservancy objectives include the protection, maintenance, rehabilitation, restoration, and enhancement of ecosystems.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Conservancies retain all income from wildlife and tourism based enterprises within the conservancy and decides on how these fund are spent. Commercial conservancies consist of adjacent private farms joining together in common units. Communal conservancies operate on a local level and membership is made up entirely of community members who decide to work together for the sustainable management and use of wildlife and tourism.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Eco-tourism
+      </h4>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Namibia has a reputation as the “Cheetah Capital of the World” and tourists come to see cheetah habitat and learn how cheetahs survive on farmland. Ecotourism focuses in animals, habitats, and places of conservation interest. Etosha National Park, the Namibia Desert and the Skeleton Coast are major attractions for foreign ecotourists. Lodges, guest farms, and commercial villages are points on Namibian ecotours. Many of these destinations promote cheetah conservation.
+      </p>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Sometime in the 2000s, the annual number of tourists visiting Namibia exceeded 500,000. Tourists spend money on transport, lodging, food and souvenirs. This is an important part of the economy and a supplement to agricultural income for many Namibians.
+      </p>
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_WhereCheetahsLive.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_WhereCheetahsLive.test.js.snap
@@ -1,0 +1,358 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EcologyPageSubsectionWhereCheetahsLive component snapshot 1`] = `
+<section
+  className="ContentPageSubsectionTemplateOuterContainer"
+>
+  <h3
+    className="ContentPageSubsectionTitle"
+  >
+    Where Cheetahs Live
+  </h3>
+  <div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Cheetah Habitat
+      </h4>
+      <div
+        className="ContentPageSideFloatFluidContainerOuterContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 598,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="African savannas have rich fauna biodiversity and house the habitats of a wide range of wildlife."
+                  className="ImageViewImg"
+                  src="savanna-min.jpg"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 598,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    African savannas have rich fauna biodiversity and house the habitats of a wide range of wildlife.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSideFloatFluidContainerFixedPartContainer"
+        >
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Animals, includes cheetah, are adapted to live in specific habitats. Cheetahs live mainly in grassland savanna. They prefer habitat which includes some cover in the form of bushes, medium length grass, trees, and small hills. Cheetahs need abundant prey in their habitat to survive and reproduce. In Namibia their habitat is densely bushed due to bush encroachment.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Cheetahs sometimes live in a wide variety of habitats. They occasionally use semi-desert, dense woodland or mountainous terrain. Older animals unable to defend territories and young cheetahs just starting to live on their own use these marginal habitats.
+          </p>
+        </div>
+      </div>
+      <img
+        alt="What is a habitat"
+        className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerSmallDimension"
+        src="What_is_Habitat_L-min.png"
+      />
+      <img
+        alt="African savanna"
+        className="FullWidth DisplayBlock RetainAspectRatio Centered"
+        src="savana_bg_large_L-min.jpg"
+      />
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Namibian Biomes
+      </h4>
+      <div
+        className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+      >
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Namibia is a country with rich biodiversity, as its land spans over five distinct types of biomes.
+            </p>
+          </div>
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+          >
+            <div
+              className="ImageSlideModalCoverTriggerOuterContainer"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "width": 480,
+                }
+              }
+            >
+              <div
+                className="ImageSlideModalCoverTriggerInnerContainer"
+                data-testid="ImageSlideModalComponentCoverImageContainerDivTestId"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "backgroundImage": "url(biome_savanna-min.jpg)",
+                    "height": 320,
+                    "width": 480,
+                  }
+                }
+              >
+                <div
+                  className="ImageSlideModalCoverTriggerImageIconInnerContainer"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="blue images outline huge icon"
+                    onClick={[Function]}
+                  />
+                </div>
+              </div>
+              <p
+                className="ContentPageCaptionTextSize"
+              >
+                Click to learn more about the biomes of Namibia.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="VerticalCushionPaddingTopLarge"
+      >
+        <div
+          className="Centered FullWidth"
+          style={
+            Object {
+              "width": 1200,
+            }
+          }
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 1200,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="Map of Namibian biomes and cheetah ranges in Namibia. Cheetahs prefer the savanna biome which supports the animals they prey on."
+                  className="ImageViewImg"
+                  src="Namibia_Biomes_and_Cheetah_Ranges_Map-min.jpg"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 1200,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    Map of Namibian biomes and cheetah ranges in Namibia. Cheetahs prefer the savanna biome which supports the animals they prey on.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <img
+        alt="What is biome?"
+        className="FullWidth DisplayBlock VerticalCushionPadding Centered FactBannerMediumDimension"
+        src="What_is_Biome_L-min.png"
+      />
+      <div
+        className="FluidSingleRowGridOuterContainer"
+        style={
+          Object {
+            "justifyContent": "space-evenly",
+          }
+        }
+      >
+        <div
+          className="ImageViewModalCoverTriggerOuterContainer"
+          data-testid="ImageViewModalComponentCoverImageContainerTestId"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "backgroundImage": "url(namibia_landscape_01-min.jpg)",
+              "height": 320,
+              "width": 480,
+            }
+          }
+        >
+          <div
+            className="ImageViewModalCoverTriggerImageIconInnerContainer"
+          >
+            <i
+              aria-hidden="true"
+              className="black file image large icon"
+              onClick={[Function]}
+            />
+          </div>
+        </div>
+        <div
+          className="ImageViewModalCoverTriggerOuterContainer"
+          data-testid="ImageViewModalComponentCoverImageContainerTestId"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "backgroundImage": "url(namibia_landscape_02-min.jpg)",
+              "height": 320,
+              "width": 480,
+            }
+          }
+        >
+          <div
+            className="ImageViewModalCoverTriggerImageIconInnerContainer"
+          >
+            <i
+              aria-hidden="true"
+              className="black file image large icon"
+              onClick={[Function]}
+            />
+          </div>
+        </div>
+        <div
+          className="ImageViewModalCoverTriggerOuterContainer"
+          data-testid="ImageViewModalComponentCoverImageContainerTestId"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "backgroundImage": "url(namibia_landscape_03-min.jpg)",
+              "height": 320,
+              "width": 480,
+            }
+          }
+        >
+          <div
+            className="ImageViewModalCoverTriggerImageIconInnerContainer"
+          >
+            <i
+              aria-hidden="true"
+              className="black file image large icon"
+              onClick={[Function]}
+            />
+          </div>
+        </div>
+        <div
+          className="ImageViewModalCoverTriggerOuterContainer"
+          data-testid="ImageViewModalComponentCoverImageContainerTestId"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          style={
+            Object {
+              "backgroundImage": "url(namibia_landscape_04-min.jpg)",
+              "height": 320,
+              "width": 480,
+            }
+          }
+        >
+          <div
+            className="ImageViewModalCoverTriggerImageIconInnerContainer"
+          >
+            <i
+              aria-hidden="true"
+              className="black file image large icon"
+              onClick={[Function]}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/future/FuturePage_Subsection_CommunityEvents.js
+++ b/src/components/future/FuturePage_Subsection_CommunityEvents.js
@@ -37,8 +37,7 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCommunityEvents._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCommunityEvents._SUBSECTION_NAME_]
     };
   }
 
@@ -82,7 +81,8 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
   }
 
   renderCCGLivelihoodDevelopmentImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ImageView

--- a/src/components/future/FuturePage_Subsection_CommunityEvents.js
+++ b/src/components/future/FuturePage_Subsection_CommunityEvents.js
@@ -37,7 +37,8 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCommunityEvents._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCommunityEvents._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -81,8 +82,7 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
   }
 
   renderCCGLivelihoodDevelopmentImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <ImageView

--- a/src/components/future/FuturePage_Subsection_CommunityEvents.js
+++ b/src/components/future/FuturePage_Subsection_CommunityEvents.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -19,6 +19,8 @@ import ContentPageSideFloatFluidContainer from '../shared/ContentPageSideFloatFl
 import {
   ContentPageSubsectionParagraphsContentBinder
 } from '../shared/ContentPageSubsectionContentBinder'
+
+import { requireContext } from '../shared/workarounds/RequireContextMock'
 
 import { GetImagePath } from '../shared/Path'
 
@@ -35,8 +37,7 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCommunityEvents._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCommunityEvents._SUBSECTION_NAME_]
     };
   }
 
@@ -80,7 +81,8 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
   }
 
   renderCCGLivelihoodDevelopmentImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ImageView

--- a/src/components/future/FuturePage_Subsection_CommunityEvents.js
+++ b/src/components/future/FuturePage_Subsection_CommunityEvents.js
@@ -81,8 +81,8 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
   }
 
   renderCCGLivelihoodDevelopmentImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <ImageView

--- a/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
+++ b/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
@@ -42,8 +42,7 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionInternshipsAndVolunteering._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionInternshipsAndVolunteering._SUBSECTION_NAME_]
     };
   }
 
@@ -93,7 +92,8 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
   }
 
   renderGetInvolvedVolunteerImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FluidImageWrapper

--- a/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
+++ b/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
@@ -42,7 +42,8 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionInternshipsAndVolunteering._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionInternshipsAndVolunteering._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -92,8 +93,7 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
   }
 
   renderGetInvolvedVolunteerImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <FluidImageWrapper

--- a/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
+++ b/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
@@ -92,8 +92,8 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
   }
 
   renderGetInvolvedVolunteerImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <FluidImageWrapper

--- a/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
+++ b/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -25,6 +25,8 @@ import {
   ContentPageSubsectionParagraphsContentBinder
 } from '../shared/ContentPageSubsectionContentBinder'
 
+import { requireContext } from '../shared/workarounds/RequireContextMock'
+
 import { GetImagePath } from '../shared/Path'
 
 import FluidImageWrapper from '../shared/FluidImageWrapper'
@@ -40,8 +42,7 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionInternshipsAndVolunteering._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionInternshipsAndVolunteering._SUBSECTION_NAME_]
     };
   }
 
@@ -91,7 +92,8 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
   }
 
   renderGetInvolvedVolunteerImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FluidImageWrapper

--- a/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
+++ b/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
@@ -48,7 +48,8 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionLivestockGuardingDogs._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionLivestockGuardingDogs._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -107,8 +108,7 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   }
 
   renderCCFLGDImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <FluidImageWrapper
@@ -199,8 +199,7 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   }
 
   renderLGDImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <FluidImageWrapper

--- a/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
+++ b/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
@@ -107,8 +107,8 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   }
 
   renderCCFLGDImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <FluidImageWrapper
@@ -199,8 +199,8 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   }
 
   renderLGDImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <FluidImageWrapper

--- a/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
+++ b/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,6 +20,8 @@ import ContentPageSideFloatFluidContainer from '../shared/ContentPageSideFloatFl
 import {
   ContentPageSubsectionParagraphsContentBinder
 } from '../shared/ContentPageSubsectionContentBinder'
+
+import { requireContext } from '../shared/workarounds/RequireContextMock'
 
 import { GetImagePath } from '../shared/Path'
 
@@ -46,8 +48,7 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionLivestockGuardingDogs._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionLivestockGuardingDogs._SUBSECTION_NAME_]
     };
   }
 
@@ -106,7 +107,8 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   }
 
   renderCCFLGDImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FluidImageWrapper
@@ -197,7 +199,8 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   }
 
   renderLGDImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FluidImageWrapper

--- a/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
+++ b/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
@@ -48,8 +48,7 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionLivestockGuardingDogs._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionLivestockGuardingDogs._SUBSECTION_NAME_]
     };
   }
 
@@ -108,7 +107,8 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   }
 
   renderCCFLGDImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FluidImageWrapper
@@ -199,7 +199,8 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   }
 
   renderLGDImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FluidImageWrapper

--- a/src/components/future/__tests__/FuturePage_Section_OutreachAndEducation.test.js
+++ b/src/components/future/__tests__/FuturePage_Section_OutreachAndEducation.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 14, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -18,27 +18,19 @@ import renderer from 'react-test-renderer'
 import FuturePageSectionOutreachAndEducation from '../FuturePage_Section_OutreachAndEducation'
 
 test('renders FuturePageSectionOutreachAndEducation component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <FuturePageSectionOutreachAndEducation
-  //     config={config}
-  //   />
-  // );
+  render(
+    <FuturePageSectionOutreachAndEducation
+      config={config}
+    />
+  );
 });
 
 test('FuturePageSectionOutreachAndEducation component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <FuturePageSectionOutreachAndEducation
-  //       config={config}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <FuturePageSectionOutreachAndEducation
+        config={config}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/future/__tests__/FuturePage_Section_SustainableDevelopment.test.js
+++ b/src/components/future/__tests__/FuturePage_Section_SustainableDevelopment.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -18,27 +18,19 @@ import renderer from 'react-test-renderer'
 import FuturePageSectionSustainableDevelopment from '../FuturePage_Section_SustainableDevelopment'
 
 test('renders FuturePageSectionSustainableDevelopment component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <FuturePageSectionSustainableDevelopment
-  //     config={config}
-  //   />
-  // );
+  render(
+    <FuturePageSectionSustainableDevelopment
+      config={config}
+    />
+  );
 });
 
 test('FuturePageSectionSustainableDevelopment component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <FuturePageSectionSustainableDevelopment
-  //       config={config}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <FuturePageSectionSustainableDevelopment
+        config={config}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/future/__tests__/FuturePage_Subsection_CommunityEvents.test.js
+++ b/src/components/future/__tests__/FuturePage_Subsection_CommunityEvents.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import FuturePageSubsectionCommunityEvents from '../FuturePage_Subsection_Commun
 const sectionConfig = config.contentPageSections["section_OutreachAndEducation"];
 
 test('renders FuturePageSubsectionCommunityEvents component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <FuturePageSubsectionCommunityEvents
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <FuturePageSubsectionCommunityEvents
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('FuturePageSubsectionCommunityEvents component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <FuturePageSubsectionCommunityEvents
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <FuturePageSubsectionCommunityEvents
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/future/__tests__/FuturePage_Subsection_InternshipsAndVolunteering.test.js
+++ b/src/components/future/__tests__/FuturePage_Subsection_InternshipsAndVolunteering.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import FuturePageSubsectionInternshipsAndVolunteering from '../FuturePage_Subsec
 const sectionConfig = config.contentPageSections["section_OutreachAndEducation"];
 
 test('renders FuturePageSubsectionInternshipsAndVolunteering component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <FuturePageSubsectionInternshipsAndVolunteering
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <FuturePageSubsectionInternshipsAndVolunteering
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('FuturePageSubsectionInternshipsAndVolunteering component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <FuturePageSubsectionInternshipsAndVolunteering
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <FuturePageSubsectionInternshipsAndVolunteering
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/future/__tests__/FuturePage_Subsection_LivestockGuardingDogs.test.js
+++ b/src/components/future/__tests__/FuturePage_Subsection_LivestockGuardingDogs.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 19, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import FuturePageSubsectionLivestockGuardingDogs from '../FuturePage_Subsection_
 const sectionConfig = config.contentPageSections["section_SustainableDevelopment"];
 
 test('renders FuturePageSubsectionLivestockGuardingDogs component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <FuturePageSubsectionLivestockGuardingDogs
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <FuturePageSubsectionLivestockGuardingDogs
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('FuturePageSubsectionLivestockGuardingDogs component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <FuturePageSubsectionLivestockGuardingDogs
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <FuturePageSubsectionLivestockGuardingDogs
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Section_OutreachAndEducation.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Section_OutreachAndEducation.test.js.snap
@@ -1,0 +1,589 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FuturePageSectionOutreachAndEducation component snapshot 1`] = `
+<article
+  className="ContentPageSectionTemplateOuterContainer"
+>
+  <h2
+    className="ContentPageSectionHeadTitle"
+    id="outreach-and-education"
+  >
+    Outreach and Education
+  </h2>
+  <p
+    className="ContentPageHeadAndSectionIntroText"
+  >
+    Public education is a vital component of any successful conservation strategies. Environmental and management education are critical in areas where people coexist intimately with the land and wildlife. Cheetah Conservation Fund believes public education and outreach will help ensure a future for the species in the wild. CCF educates farmers, teachers, students, and the public about methods to conserve biodiversity, as well as champion the idea that everybody can be a custodian of nature and has something to contribute.
+  </p>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Field Research
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+      >
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+          >
+            <div>
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Veterinary Clinic
+              </h4>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                The HASS Family Research Center houses CCF’s registered on-site veterinary clinic. The clinic allows CCF to provide medical care for cheetahs within the sanctuary, CCF Livestock Guarding Dogs and CCF’s livestock. In addition, all cheetahs that CCF studies receive a full biomedical work-up and health assessment.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Other clinical procedures include routine medical checks, dental care and when necessary, surgery. While working with these animals, CCF research staff can collect biological samples that are used to do health evaluation, reproduction studies and to determine the cheetah population’s genetic status and provide the basis of a disease surveillance system for cheetahs, these biological samples also aid in future research.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Wild cheetahs that come into the clinic are marked with a transponder ear tag and/or fitted with a radio or satellite tracking collar before release back into the wild. CCF works with the Namibian Ministry of Environment and Tourism and neighboring farmers to determine a suitable habitat for relocation if necessary, or release on the farm where the cheetah was caught.
+              </p>
+            </div>
+          </div>
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+          >
+            <div>
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Ecological Studies
+              </h4>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Satellite tracking collars provide important data for CCF research teams. Researchers can monitor the daily movement of the cheetah, track its hunting skills and monitor its general well-being in the wild. If also allows researchers to evaluate the cheetah’s habitat use and prey preference.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Satellite and VHS monitoring collars, as well as camera traps help determine animal home ranges, habitat preferences and seasonal use, territoriality and behaviors unique to individual cheetah populations.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                CCF conducts vegetation studies that include monitoring growth patterns of bush within targeted study areas on CCF land. Information on vegetation is used to identify target areas for ecological management and help determine and monitor the manner with which bush encroachment affects the biodiversity of the land.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="VerticalCushionPadding"
+      >
+        <div>
+          <a
+            href="https://cheetah.org/about/what-we-do/research/"
+          >
+            <button
+              className="ui blue icon button"
+              onClick={[Function]}
+            >
+              Learn more about CCF's research work
+              <i
+                aria-hidden="true"
+                className="file alternate outline icon"
+                onClick={[Function]}
+              />
+            </button>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Internships and Volunteering
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="Centered FullWidth"
+          style={
+            Object {
+              "width": 1300,
+            }
+          }
+        >
+          <img
+            alt="CCF Volunteering"
+            className="FullWidth DisplayBlock RetainAspectRatio"
+            src="CCF_GetInvolved_Volunteer_L-min.jpg"
+          />
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+          >
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+            >
+              <div>
+                <h4
+                  className="ContentPageSubsectionSubtitle"
+                >
+                  Internships
+                </h4>
+                <p
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                >
+                  CCF welcomes a selected number of students each year with a wide variety of backgrounds and courses of study. Graduate and undergraduate students are given a chance to learn about aspects of conservation biology, ecology, veterinary medicine, genetics, animal science, agriculture, sociology, business, computing, graphic design, education and tourism.
+                </p>
+                <p
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                >
+                  CCF is an official fourth year placement for students from Namibia’s two major universities, University of Namibia (UNAM) and Namibia University of Science and Technology (NUST). In addition, CCF welcomes interns from undergraduate and graduate university programs all over the world.
+                </p>
+                <p
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                >
+                  Aspiring biologists, genetics, and ecologists pursuing Masters and Ph.D. degrees come to CCF to work on research and thesis projects all year.
+                </p>
+                <ul>
+                  <li
+                    className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                  >
+                    cheetah feeding - collecting and dissecting cheetah feces
+                  </li>
+                  <li
+                    className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                  >
+                    observing cheetah behavior - assisting in clinical work-ups
+                  </li>
+                  <li
+                    className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                  >
+                    raise livestock guarding dog puppies - conducting field work
+                  </li>
+                  <li
+                    className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                  >
+                    being involved with outreach and education programs
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <div
+              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+            >
+              <div>
+                <h4
+                  className="ContentPageSubsectionSubtitle"
+                >
+                  Volunteering
+                </h4>
+                <p
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                >
+                  Volunteering at CCF in Namibia is a rewarding experience, and most of the people who participate in our volunteer program will tell you that it is among the best experiences they have ever had. Volunteers do everything from data entry and camera trap photo sorting to chopping up meat to collecting and cataloging scat samples.
+                </p>
+                <p
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                >
+                  Like interns, volunteers can expect to work on a variety of tasks. CCF also seeks professionally skilled volunteers to work as cheetah keepers, animal behavior specialists, ecologists, biologists, veterinarians, and vet-technicians, as well as educators, trainers, and conservationists.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div>
+          <a
+            href="https://cheetah.org/get-involved/volunteer/"
+          >
+            <button
+              className="ui blue icon button"
+              onClick={[Function]}
+            >
+              Learn more about CCF's Volunteer Program
+              <i
+                aria-hidden="true"
+                className="file alternate outline icon"
+                onClick={[Function]}
+              />
+            </button>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      The Role of Zoos
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Moderns zoos serve as conservation education centers and provide sanctuary for many endangered species. Cooperative breeding, management and research have assisted in re-establishing some species in the wild.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Historically, cheetahs have not bred well in captivity. In recent years, through cooperative research and management in zoos worldwide, a global master plan is producing successful results. If future extinction were to occur with wild cheetahs, this research and maintained captive populations could allow the re-introduction of cheetahs.
+        </p>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Ambassadors
+        </h4>
+        <div
+          className="ContentPageSideFloatFluidContainerOuterContainer"
+        >
+          <div
+            className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+          >
+            <div
+              className="ImageViewOuterContainer"
+              style={
+                Object {
+                  "maxWidth": 720,
+                }
+              }
+            >
+              <div
+                className="ImageViewInnerContainer"
+              >
+                <div
+                  className="ImageViewImgContainer"
+                >
+                  <img
+                    alt="In 2009, Cincinnati Zoo's cheetah Sarah set the record of the world's fastest cheetah, as she sprant 100m in just 6.13 seconds. The best record for 100m by humans was from Usain Bolt, finishing in 9.58 seconds."
+                    className="ImageViewImg"
+                    src="cincinnati_zoo_cheetah_sarah-min.jpg"
+                  />
+                </div>
+                <div
+                  className="ImageViewCaptionContainer"
+                >
+                  <div
+                    className="CaptionContainer"
+                    data-testid="CaptionComponentTestId"
+                    style={
+                      Object {
+                        "maxWidth": 720,
+                      }
+                    }
+                  >
+                    <div
+                      className="IconContainer"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="image icon"
+                        onClick={[Function]}
+                      />
+                    </div>
+                    <p
+                      className="ContentPageCaptionTextSize CaptionText"
+                    >
+                      In 2009, Cincinnati Zoo's cheetah Sarah set the record of the world's fastest cheetah, as she sprant 100m in just 6.13 seconds. The best record for 100m by humans was from Usain Bolt, finishing in 9.58 seconds.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ContentPageSideFloatFluidContainerFixedPartContainer"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              As representatives of the wild cheetah, zoo animals provide the opportunity for people around the world to see a cheetah close up.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Through educational programs, zoos spark the interest of individuals who can support or join the projects that will save wild cheetahs.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Zoos contribute to the conservation of wild cheetahs through education, research and support.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Research
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Zoos, universities, private individuals, governmental and NGOs support cooperative efforts worldwide.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Reproductive, medical and behavioral studies, and laboratory analysis are cooperative conservation efforts between captive and wild cheetah.
+        </p>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Schools, Teachers, Learners
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+      >
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              CCF develops outreach school programs and educational packets are distributed to students and teachers. All schools are welcomed to CCF facilities.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Staff members conduct assemblies throughout Namibia. Students are encouraged to become more involved in conservation in school and in their homes. Workshops assist teachers in initiating cheetah conservation and environmental education programs.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Educational facilities at CCF’s headquarters encourage participation in cheetah conservation. The Education Center, the Visitor Center and Predator-Preyground provide information in an interacting setting. CCF’s Wildlife Camp allows outdoor education and a wilderness experience. A Nature Trail highlights the farmland ecosystem and the valuable role of predators.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              CCF takes a cross-curricular approach, integrating conservation issues into subjects that are required as part of the school syllabus and donates books to schools and libraries.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              CCF works with government agencies to incorporate cheetah conservation in the school curriculum.
+            </p>
+          </div>
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+          >
+            <div
+              className="ImageSlidingGalleryOuterContainer"
+              style={
+                Object {
+                  "maxWidth": undefined,
+                }
+              }
+            >
+              <div
+                className="ImageSlidingGalleryCoreContainer"
+              >
+                <img
+                  alt="CCF's Predator Preyground. (Image credit: Cheetah Conservation Fund)"
+                  className="ImageSlidingGalleryImgPart"
+                  src="CCF_Predator_Preyground-min.jpg"
+                />
+                <div
+                  className="ImageSlidingGalleryButtonContainer"
+                >
+                  <div
+                    aria-label="Previous slide"
+                    className="ui blue huge icon left attached disabled button"
+                    onClick={[Function]}
+                    role="button"
+                    tabIndex={-1}
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="arrow alternate circle left outline icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <div
+                    aria-label="Next slide"
+                    className="ui blue huge icon right attached button"
+                    onClick={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="arrow alternate circle right outline icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ImageSlidingGalleryCaptionPart"
+                data-testid="ImageSlidingGalleryCaptionPart"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    CCF's Predator Preyground. (Image credit: Cheetah Conservation Fund)
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <div>
+    <section
+      className="ContentPageSubsectionTemplateOuterContainer"
+    >
+      <h3
+        className="ContentPageSubsectionTitle"
+      >
+        Community Events
+      </h3>
+      <div
+        className="ContentPageSideFloatFluidContainerOuterContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatLeft"
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 960,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="CCF helps Namibian artists and artisans to market and sell their work with the Livelihood Development Program."
+                  className="ImageViewImg"
+                  src="CCF_Livelihood_Development_L-min.jpg"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 960,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    CCF helps Namibian artists and artisans to market and sell their work with the Livelihood Development Program. (Image credit: Cheetah Conservation Fund)
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSideFloatFluidContainerFixedPartContainer"
+        >
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Participatory community events, such as competitions in art, poetry and writing, increase conservation awareness.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Public educational displays are maintained at strategic locations and community events. Displays provide introductory information on the plight of the cheetah and the work conducted by CCF.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            CCF staff participate in farmer meetings, local conservancy activities and other related events. Workshops and seminars are conducted to exchange information and develop conservation-based farming practices.
+          </p>
+        </div>
+      </div>
+    </section>
+  </div>
+</article>
+`;

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Section_SustainableDevelopment.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Section_SustainableDevelopment.test.js.snap
@@ -1,0 +1,559 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FuturePageSectionSustainableDevelopment component snapshot 1`] = `
+<article
+  className="ContentPageSectionTemplateOuterContainer"
+>
+  <h2
+    className="ContentPageSectionHeadTitle"
+    id="sustainable-development"
+  >
+    Sustainable Development
+  </h2>
+  <p
+    className="ContentPageHeadAndSectionIntroText"
+  >
+    Sustainable development is key to ensure long term utilizations of natural resources without compromising the integrity of the ecosystem and the sharing of resources by other species. Part of sustainable development involves taking part of the revenue generated from any human development and contribute that to the nurturing and protection of the entire ecosystem. Any human development can be turned to be sustainable by employing the best practices of land, livestock, and wildlife management techniques that have proven to be effective and successful.
+  </p>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Mission Possible
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          In Africa, property that is owned and managed by farmers can maintain viable populations of animals and natural habitats. It is the careful management of these habitats that holds the key to the future survival of plant and animal species such as the cheetah.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          In order to ensure a successful future we need to be responsible custodians of nature. The way land and animals are managed determines the future of all ecosystems.
+        </p>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="ContentPageSubsectionThreeColumnContentTemplateOuterContainer"
+        >
+          <div
+            className="ContentPageSubsectionThreeColumnContentTemplateInnerContainer"
+          >
+            <div
+              className="ContentPageSubsectionThreeColumnContentTemplateColumn ContentPageSubsectionThreeColumnContentTemplateLeftColumnContainer"
+            >
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Land Management
+              </h4>
+              <div>
+                <p
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                >
+                  The productivity of the land depends on water and soil. Preventing erosion increases the potential for the land to produce food and allows water to penetrate the soil, thus carrying important nutrients to the roots of the plants. We must learn to live within the limits of the scarcity of water in our dry country.
+                </p>
+                <p
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                >
+                  The use of alternative fuels or efficient wood burning stoves and ovens reduces deforestation. Establishing timber plantations and using alternative building materials saves natural forests.
+                </p>
+              </div>
+            </div>
+            <div
+              className="ContentPageSubsectionThreeColumnContentTemplateColumn ContentPageSubsectionThreeColumnContentTemplateMiddleColumnContainer"
+              style={
+                Object {
+                  "backgroundColor": "rgb(undefined)",
+                }
+              }
+            >
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Livestock Management
+              </h4>
+              <div>
+                <div>
+                  <p
+                    className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                  >
+                    Many farmers use rotational grazing where farmlands are divided into camps. Practicing rotational and seasonal grazing allows used areas time to recover.
+                  </p>
+                  <p
+                    className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                  >
+                    Recovery of damaged land occurs faster if it is protected from the impact of overgrazing. Proper herd size is necessary to prevent overgrazing, trampling of the land and reducing predator problems. A balance of grazing and browsing animals reduces the pressure on one vegetation type.
+                  </p>
+                  <img
+                    alt="Sustainable development"
+                    className="FullWidth"
+                    src="Sustainable_Development-min.png"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className="ContentPageSubsectionThreeColumnContentTemplateColumn ContentPageSubsectionThreeColumnContentTemplateRightColumnContainer"
+            >
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Wildlife Management
+              </h4>
+              <div>
+                <p
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                >
+                  Allowing wild animals to migrate naturally through farm areas promotes the balance of browsers and grazers, and allows predators their food at wild game. This reduces the temptation to take domestic stock.
+                </p>
+                <p
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+                >
+                  Ethical hunting removes older animals while predators prey on the young, diseased, and genetically weak. Together they keep wild herds healthy and in check.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Future Farmers of Africa
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerOuterContainer"
+        >
+          <div
+            className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+          >
+            <div
+              style={
+                Object {
+                  "width": 240,
+                }
+              }
+            >
+              <div
+                className="ui inverted segment StatsLabel"
+              >
+                <div
+                  className="ui orange huge inverted statistic"
+                >
+                  <div
+                    className="value"
+                  >
+                    90%
+                  </div>
+                  <div
+                    className="label"
+                  >
+                    of the cheetah population in Namibia lives on farmlands alongside 80% of the country’s wildlife species
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ContentPageSideFloatFluidContainerFixedPartContainer"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              In Namibia, 90% of the cheetah population lives on farmlands alongside 80% of the country’s wildlife species. Cheetahs often come into contact with the livestocks and game farming communities, leading to conflict. To mitigate this conflict, Cheetah Conservation Fund (CCF) developed an integrated livestock, wildlife, and rangeland training program called Future Farmers of Africa (FFA).
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerOuterContainer"
+        >
+          <div
+            className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatLeft"
+          >
+            <div
+              className="ImageViewOuterContainer"
+              style={
+                Object {
+                  "maxWidth": 742,
+                }
+              }
+            >
+              <div
+                className="ImageViewInnerContainer"
+              >
+                <div
+                  className="ImageViewImgContainer"
+                >
+                  <img
+                    alt="Farmers participate in FFA training courses."
+                    className="ImageViewImg"
+                    src="CCF_FFA_01-min.jpg"
+                  />
+                </div>
+                <div
+                  className="ImageViewCaptionContainer"
+                >
+                  <div
+                    className="CaptionContainer"
+                    data-testid="CaptionComponentTestId"
+                    style={
+                      Object {
+                        "maxWidth": 742,
+                      }
+                    }
+                  >
+                    <div
+                      className="IconContainer"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="image icon"
+                        onClick={[Function]}
+                      />
+                    </div>
+                    <p
+                      className="ContentPageCaptionTextSize CaptionText"
+                    >
+                      Farmers participate in FFA training courses. (Image credit: Cheetah Conservation Fund)
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ContentPageSideFloatFluidContainerFixedPartContainer"
+          >
+            <div>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                From 2006-2017, CCF has certified more than 10,000 Namibian men and women in FFA, which teaches conservation strategies for sustainable land use while accommodating the coexistence of predators alongside livestock and wildlife.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Topics covered in the FFA courses include livestock health and veterinary care, livestock husbandry, livestock valuation, predator spoor (track) identification, differentiating predator kill techniques, best practices to reduce livestock losses, and best methods for non-lethal predator control.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Through the training course, CCF supports farmers by teaching them practical skills in sustainable livestock farming, as well as how to develop supplemental income streams. Farmers then use their skills to generate higher economic productivity. These courses enhance the livelihood development of farmers while promoting predator-friendly farming practices.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          CCF’s Integrated Livestock and Wildlife Model Farm houses cattle, goats, sheep and livestock guarding dogs, as well as Namibian wildlife. The Model Farm serves as a training facility for FFA, demonstrating how sustainable livestock farming practices allow for the management of their livestock and better livestock health without having to eliminate cheetahs and other predators.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          CCF reaches out to local farming communities, visiting farms and joining annual farmer’s association meetings to give vital advice on improvements that farmers can make to their rangeland, livestock and wildlife management.
+        </p>
+        <div
+          className="VerticalCushionPadding"
+        >
+          <div>
+            <a
+              href="https://cheetah.org/canada/about-us/what-we-support/future-farmers-of-africa/"
+            >
+              <button
+                className="ui blue icon button"
+                onClick={[Function]}
+              >
+                Read on CCF's blog on Future Farmers of Africa
+                <i
+                  aria-hidden="true"
+                  className="file alternate outline icon"
+                  onClick={[Function]}
+                />
+              </button>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Livestock Guarding Dogs
+    </h3>
+    <div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          CCF’s Livestock Guarding Dog History
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          In 1994, CCF created a solution to non-lethal predator control - Livestock Guarding Dogs (LGD). After extensive research, CCF felt that the Anatolian Shepherd and Kangal dogs best met the livestock managers’ needs in Namibia. In cooperation with Dr. Ray Coppinger from the Livestock Guarding Dog Association in Hampshire College (Massachusetts, U.S.), the first 10 dogs were donated to Namibia by Birinci Anatolians.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Since then, hundreds of farmers have received Anatolian Shepherds and Kangal dogs to ward off predators, such as cheetahs, jackals and leopards. These dogs do not herd the goats, but protect the flock by placing themselves between the herd and the predator and barking loudly.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          CCF’s success is due to the commitment of CCF staff members and the participating farmers. CCF staff regularly visit the farms, educating and advising the farmers and herders for the dogs to be as effective as possible.
+        </p>
+        <div
+          className="VerticalCushionPadding"
+        >
+          <div
+            className="Centered FullWidth"
+            style={
+              Object {
+                "width": 1200,
+              }
+            }
+          >
+            <img
+              alt="Livestock Guarding Dog"
+              className="FullWidth DisplayBlock RetainAspectRatio"
+              src="CCF_LGD_L-min.jpg"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Raising LGD’s
+        </h4>
+        <div
+          className="ContentPageSideFloatFluidContainerOuterContainer"
+        >
+          <div
+            className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+          >
+            <div
+              className="ImageViewOuterContainer"
+              style={
+                Object {
+                  "maxWidth": 720,
+                }
+              }
+            >
+              <div
+                className="ImageViewInnerContainer"
+              >
+                <div
+                  className="ImageViewImgContainer"
+                >
+                  <img
+                    alt="Anatolian Shepherd puppies live alongside with the herd."
+                    className="ImageViewImg"
+                    src="CCF_anatolian_shepherd_puppies-min.jpg"
+                  />
+                </div>
+                <div
+                  className="ImageViewCaptionContainer"
+                >
+                  <div
+                    className="CaptionContainer"
+                    data-testid="CaptionComponentTestId"
+                    style={
+                      Object {
+                        "maxWidth": 720,
+                      }
+                    }
+                  >
+                    <div
+                      className="IconContainer"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="image icon"
+                        onClick={[Function]}
+                      />
+                    </div>
+                    <p
+                      className="ContentPageCaptionTextSize CaptionText"
+                    >
+                      Anatolian Shepherd puppies live alongside with the herd. (Image credit: Cheetah Conservation Fund)
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ContentPageSideFloatFluidContainerFixedPartContainer"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              LGD’s are placed with their herds around nine weeks of age, as social bonding between the stock and the dogs deepens upon imprinting before 16 weeks of age. The dogs live with their livestock family instead of a human family, so the puppies bond with the herd; it becomes the dog’s pack rather than the dog’s potential prey. At CCF puppies are born in a whelping pen attached to the main goat yard.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <div
+          className="Centered FullWidth"
+          style={
+            Object {
+              "width": 1000,
+            }
+          }
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 1000,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="Established in 1994, 2019 marked the 25th anniversary of CCF's Livestock Guarding Dog program."
+                  className="ImageViewImg"
+                  src="CCF_Year_of_the_LGD-min.jpg"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 1000,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    Established in 1994, 2019 marked the 25th anniversary of CCF's Livestock Guarding Dog program. (Image credit: Cheetah Conservation Fund)
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Dogs Save Cheetahs
+        </h4>
+        <div
+          className="ContentPageSideFloatFluidContainerOuterContainer"
+        >
+          <div
+            className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+          >
+            <img
+              alt="Cheetah and LGD"
+              className="FullWidth DisplayBlock RetainAspectRatio"
+              src="Cheetah_and_LGD-min.jpg"
+            />
+          </div>
+          <div
+            className="ContentPageSideFloatFluidContainerFixedPartContainer"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Livestock Guarding Dogs have been used for thousands of years to protect cattle, sheep and goats from predator attacks. There are over 20 breeds of guarding dogs. The Anatolian Shepherd, a Turkish breed, was selected as the best candidate for use with smallstock in Namibia as they are able to work in vast open spaces without direct guidance. These dogs look similar to the flock, with large rounded heads, floppy ears and short fur. They have a good sense of hearing and smelling, a calm temperament and a very loud bark.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Anatolians do not herd livestock, they guard them. They are attentive, protective, trustworthy, and aggressive towards predator threats.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Puppies are placed with the stock at eight weeks of age to form a strong bond with the herd. It is important that bonding occurs with the herd and not with humans or other dogs.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Dog owners take the responsibility for the health care of their dogs. This includes veterinary check-ups, vaccinations, and observations for signs of illness or injuries.
+            </p>
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              An appropriate diet is necessary for the Anatolian Shepherd. Enough food allows proper growth and a healthy dog. They should never be given raw meat as this could produce a predatory response. They need water during the day when they are out with the herd.
+            </p>
+          </div>
+        </div>
+        <div
+          className="VerticalCushionPaddingTopLarge"
+        >
+          <img
+            alt="Livestock Guarding Dogs"
+            className="FullWidth DisplayBlock RetainAspectRatio Centered"
+            src="LGD_960x960_L-min.png"
+          />
+        </div>
+      </div>
+    </div>
+  </section>
+</article>
+`;

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_CommunityEvents.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_CommunityEvents.test.js.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FuturePageSubsectionCommunityEvents component snapshot 1`] = `
+<div>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Community Events
+    </h3>
+    <div
+      className="ContentPageSideFloatFluidContainerOuterContainer"
+    >
+      <div
+        className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatLeft"
+      >
+        <div
+          className="ImageViewOuterContainer"
+          style={
+            Object {
+              "maxWidth": 960,
+            }
+          }
+        >
+          <div
+            className="ImageViewInnerContainer"
+          >
+            <div
+              className="ImageViewImgContainer"
+            >
+              <img
+                alt="CCF helps Namibian artists and artisans to market and sell their work with the Livelihood Development Program."
+                className="ImageViewImg"
+                src="CCF_Livelihood_Development_L-min.jpg"
+              />
+            </div>
+            <div
+              className="ImageViewCaptionContainer"
+            >
+              <div
+                className="CaptionContainer"
+                data-testid="CaptionComponentTestId"
+                style={
+                  Object {
+                    "maxWidth": 960,
+                  }
+                }
+              >
+                <div
+                  className="IconContainer"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="image icon"
+                    onClick={[Function]}
+                  />
+                </div>
+                <p
+                  className="ContentPageCaptionTextSize CaptionText"
+                >
+                  CCF helps Namibian artists and artisans to market and sell their work with the Livelihood Development Program. (Image credit: Cheetah Conservation Fund)
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ContentPageSideFloatFluidContainerFixedPartContainer"
+      >
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Participatory community events, such as competitions in art, poetry and writing, increase conservation awareness.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          Public educational displays are maintained at strategic locations and community events. Displays provide introductory information on the plight of the cheetah and the work conducted by CCF.
+        </p>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          CCF staff participate in farmer meetings, local conservancy activities and other related events. Workshops and seminars are conducted to exchange information and develop conservation-based farming practices.
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+`;

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_InternshipsAndVolunteering.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_InternshipsAndVolunteering.test.js.snap
@@ -1,0 +1,135 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FuturePageSubsectionInternshipsAndVolunteering component snapshot 1`] = `
+<section
+  className="ContentPageSubsectionTemplateOuterContainer"
+>
+  <h3
+    className="ContentPageSubsectionTitle"
+  >
+    Internships and Volunteering
+  </h3>
+  <div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <div
+        className="Centered FullWidth"
+        style={
+          Object {
+            "width": 1300,
+          }
+        }
+      >
+        <img
+          alt="CCF Volunteering"
+          className="FullWidth DisplayBlock RetainAspectRatio"
+          src="CCF_GetInvolved_Volunteer_L-min.jpg"
+        />
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <div
+        className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+      >
+        <div
+          className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+        >
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerLhs"
+          >
+            <div>
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Internships
+              </h4>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                CCF welcomes a selected number of students each year with a wide variety of backgrounds and courses of study. Graduate and undergraduate students are given a chance to learn about aspects of conservation biology, ecology, veterinary medicine, genetics, animal science, agriculture, sociology, business, computing, graphic design, education and tourism.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                CCF is an official fourth year placement for students from Namibia’s two major universities, University of Namibia (UNAM) and Namibia University of Science and Technology (NUST). In addition, CCF welcomes interns from undergraduate and graduate university programs all over the world.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Aspiring biologists, genetics, and ecologists pursuing Masters and Ph.D. degrees come to CCF to work on research and thesis projects all year.
+              </p>
+              <ul>
+                <li
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                >
+                  cheetah feeding - collecting and dissecting cheetah feces
+                </li>
+                <li
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                >
+                  observing cheetah behavior - assisting in clinical work-ups
+                </li>
+                <li
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                >
+                  raise livestock guarding dog puppies - conducting field work
+                </li>
+                <li
+                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight"
+                >
+                  being involved with outreach and education programs
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div
+            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainerRhs"
+          >
+            <div>
+              <h4
+                className="ContentPageSubsectionSubtitle"
+              >
+                Volunteering
+              </h4>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Volunteering at CCF in Namibia is a rewarding experience, and most of the people who participate in our volunteer program will tell you that it is among the best experiences they have ever had. Volunteers do everything from data entry and camera trap photo sorting to chopping up meat to collecting and cataloging scat samples.
+              </p>
+              <p
+                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+              >
+                Like interns, volunteers can expect to work on a variety of tasks. CCF also seeks professionally skilled volunteers to work as cheetah keepers, animal behavior specialists, ecologists, biologists, veterinarians, and vet-technicians, as well as educators, trainers, and conservationists.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <div>
+        <a
+          href="https://cheetah.org/get-involved/volunteer/"
+        >
+          <button
+            className="ui blue icon button"
+            onClick={[Function]}
+          >
+            Learn more about CCF's Volunteer Program
+            <i
+              aria-hidden="true"
+              className="file alternate outline icon"
+              onClick={[Function]}
+            />
+          </button>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_LivestockGuardingDogs.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_LivestockGuardingDogs.test.js.snap
@@ -1,0 +1,256 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FuturePageSubsectionLivestockGuardingDogs component snapshot 1`] = `
+<section
+  className="ContentPageSubsectionTemplateOuterContainer"
+>
+  <h3
+    className="ContentPageSubsectionTitle"
+  >
+    Livestock Guarding Dogs
+  </h3>
+  <div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        CCF’s Livestock Guarding Dog History
+      </h4>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        In 1994, CCF created a solution to non-lethal predator control - Livestock Guarding Dogs (LGD). After extensive research, CCF felt that the Anatolian Shepherd and Kangal dogs best met the livestock managers’ needs in Namibia. In cooperation with Dr. Ray Coppinger from the Livestock Guarding Dog Association in Hampshire College (Massachusetts, U.S.), the first 10 dogs were donated to Namibia by Birinci Anatolians.
+      </p>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        Since then, hundreds of farmers have received Anatolian Shepherds and Kangal dogs to ward off predators, such as cheetahs, jackals and leopards. These dogs do not herd the goats, but protect the flock by placing themselves between the herd and the predator and barking loudly.
+      </p>
+      <p
+        className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+      >
+        CCF’s success is due to the commitment of CCF staff members and the participating farmers. CCF staff regularly visit the farms, educating and advising the farmers and herders for the dogs to be as effective as possible.
+      </p>
+      <div
+        className="VerticalCushionPadding"
+      >
+        <div
+          className="Centered FullWidth"
+          style={
+            Object {
+              "width": 1200,
+            }
+          }
+        >
+          <img
+            alt="Livestock Guarding Dog"
+            className="FullWidth DisplayBlock RetainAspectRatio"
+            src="CCF_LGD_L-min.jpg"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Raising LGD’s
+      </h4>
+      <div
+        className="ContentPageSideFloatFluidContainerOuterContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+        >
+          <div
+            className="ImageViewOuterContainer"
+            style={
+              Object {
+                "maxWidth": 720,
+              }
+            }
+          >
+            <div
+              className="ImageViewInnerContainer"
+            >
+              <div
+                className="ImageViewImgContainer"
+              >
+                <img
+                  alt="Anatolian Shepherd puppies live alongside with the herd."
+                  className="ImageViewImg"
+                  src="CCF_anatolian_shepherd_puppies-min.jpg"
+                />
+              </div>
+              <div
+                className="ImageViewCaptionContainer"
+              >
+                <div
+                  className="CaptionContainer"
+                  data-testid="CaptionComponentTestId"
+                  style={
+                    Object {
+                      "maxWidth": 720,
+                    }
+                  }
+                >
+                  <div
+                    className="IconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="image icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                  <p
+                    className="ContentPageCaptionTextSize CaptionText"
+                  >
+                    Anatolian Shepherd puppies live alongside with the herd. (Image credit: Cheetah Conservation Fund)
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ContentPageSideFloatFluidContainerFixedPartContainer"
+        >
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            LGD’s are placed with their herds around nine weeks of age, as social bonding between the stock and the dogs deepens upon imprinting before 16 weeks of age. The dogs live with their livestock family instead of a human family, so the puppies bond with the herd; it becomes the dog’s pack rather than the dog’s potential prey. At CCF puppies are born in a whelping pen attached to the main goat yard.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <div
+        className="Centered FullWidth"
+        style={
+          Object {
+            "width": 1000,
+          }
+        }
+      >
+        <div
+          className="ImageViewOuterContainer"
+          style={
+            Object {
+              "maxWidth": 1000,
+            }
+          }
+        >
+          <div
+            className="ImageViewInnerContainer"
+          >
+            <div
+              className="ImageViewImgContainer"
+            >
+              <img
+                alt="Established in 1994, 2019 marked the 25th anniversary of CCF's Livestock Guarding Dog program."
+                className="ImageViewImg"
+                src="CCF_Year_of_the_LGD-min.jpg"
+              />
+            </div>
+            <div
+              className="ImageViewCaptionContainer"
+            >
+              <div
+                className="CaptionContainer"
+                data-testid="CaptionComponentTestId"
+                style={
+                  Object {
+                    "maxWidth": 1000,
+                  }
+                }
+              >
+                <div
+                  className="IconContainer"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="image icon"
+                    onClick={[Function]}
+                  />
+                </div>
+                <p
+                  className="ContentPageCaptionTextSize CaptionText"
+                >
+                  Established in 1994, 2019 marked the 25th anniversary of CCF's Livestock Guarding Dog program. (Image credit: Cheetah Conservation Fund)
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ContentPageSubsectionPartContainer"
+    >
+      <h4
+        className="ContentPageSubsectionSubtitle"
+      >
+        Dogs Save Cheetahs
+      </h4>
+      <div
+        className="ContentPageSideFloatFluidContainerOuterContainer"
+      >
+        <div
+          className="ContentPageSideFloatFluidContainerFloatPartContainer BottomMargin20px FloatRight"
+        >
+          <img
+            alt="Cheetah and LGD"
+            className="FullWidth DisplayBlock RetainAspectRatio"
+            src="Cheetah_and_LGD-min.jpg"
+          />
+        </div>
+        <div
+          className="ContentPageSideFloatFluidContainerFixedPartContainer"
+        >
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Livestock Guarding Dogs have been used for thousands of years to protect cattle, sheep and goats from predator attacks. There are over 20 breeds of guarding dogs. The Anatolian Shepherd, a Turkish breed, was selected as the best candidate for use with smallstock in Namibia as they are able to work in vast open spaces without direct guidance. These dogs look similar to the flock, with large rounded heads, floppy ears and short fur. They have a good sense of hearing and smelling, a calm temperament and a very loud bark.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Anatolians do not herd livestock, they guard them. They are attentive, protective, trustworthy, and aggressive towards predator threats.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Puppies are placed with the stock at eight weeks of age to form a strong bond with the herd. It is important that bonding occurs with the herd and not with humans or other dogs.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Dog owners take the responsibility for the health care of their dogs. This includes veterinary check-ups, vaccinations, and observations for signs of illness or injuries.
+          </p>
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            An appropriate diet is necessary for the Anatolian Shepherd. Enough food allows proper growth and a healthy dog. They should never be given raw meat as this could produce a predatory response. They need water during the day when they are out with the herd.
+          </p>
+        </div>
+      </div>
+      <div
+        className="VerticalCushionPaddingTopLarge"
+      >
+        <img
+          alt="Livestock Guarding Dogs"
+          className="FullWidth DisplayBlock RetainAspectRatio Centered"
+          src="LGD_960x960_L-min.png"
+        />
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
+++ b/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
@@ -118,8 +118,8 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
   }
 
   renderBigCatsImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <FluidImageWrapper

--- a/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
+++ b/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
@@ -52,8 +52,7 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionFelidaeFamilyTree._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionFelidaeFamilyTree._SUBSECTION_NAME_]
     };
   }
 
@@ -119,7 +118,8 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
   }
 
   renderBigCatsImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FluidImageWrapper

--- a/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
+++ b/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React, { Suspense } from 'react'
@@ -12,6 +12,8 @@ import React, { Suspense } from 'react'
 import Media from 'react-media'
 
 import { getElementStyleClassName } from '../../styling/styling'
+
+import { requireContext } from '../shared/workarounds/RequireContextMock'
 
 import { GetImagePath } from '../shared/Path'
 
@@ -50,8 +52,7 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionFelidaeFamilyTree._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionFelidaeFamilyTree._SUBSECTION_NAME_]
     };
   }
 
@@ -117,7 +118,8 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
   }
 
   renderBigCatsImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <FluidImageWrapper

--- a/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
+++ b/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
@@ -52,7 +52,8 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionFelidaeFamilyTree._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionFelidaeFamilyTree._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -118,8 +119,7 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
   }
 
   renderBigCatsImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <FluidImageWrapper

--- a/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
+++ b/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
@@ -54,8 +54,7 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionRoadToExtinction._SUBSECTION_NAME_],
-      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionRoadToExtinction._SUBSECTION_NAME_]
     };
   }
 
@@ -98,7 +97,8 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
   }
 
   renderCheetahEvolutionAndExtinctionScaleImage(matches) {
-    const images = this.state.imagesContext("./assets/");
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ContentPageSubsectionPart>

--- a/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
+++ b/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
@@ -4,12 +4,14 @@
  *
  * Author   : Tomiko
  * Created  : Jul 10, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
 
 import Media from 'react-media'
+
+import { requireContext } from '../shared/workarounds/RequireContextMock'
 
 import ContentPageSubsectionTemplate from '../shared/ContentPageSubsectionTemplate'
 import ContentPageSubsectionTwoColumnContentTemplate from '../shared/ContentPageSubsectionTwoColumnContentTemplate'
@@ -52,8 +54,7 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionRoadToExtinction._SUBSECTION_NAME_],
-      imagesContext: () => (require.context("./assets/", true))
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionRoadToExtinction._SUBSECTION_NAME_]
     };
   }
 
@@ -96,7 +97,8 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
   }
 
   renderCheetahEvolutionAndExtinctionScaleImage(matches) {
-    const images = this.state.imagesContext();
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+    const images = context(__dirname);
 
     return (
       <ContentPageSubsectionPart>

--- a/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
+++ b/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
@@ -97,8 +97,8 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
   }
 
   renderCheetahEvolutionAndExtinctionScaleImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/")) : () => (require.context("./assets/"));
+    const images = context();
 
     return (
       <ContentPageSubsectionPart>

--- a/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
+++ b/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
@@ -54,7 +54,8 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionRoadToExtinction._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionRoadToExtinction._SUBSECTION_NAME_],
+      imagesContext: __TEST__ ? (base) => (requireContext(__dirname, base)) : (base) => (require.context(base))
     };
   }
 
@@ -97,8 +98,7 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
   }
 
   renderCheetahEvolutionAndExtinctionScaleImage(matches) {
-    const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
-    const images = context(__dirname);
+    const images = this.state.imagesContext("./assets/");
 
     return (
       <ContentPageSubsectionPart>

--- a/src/components/history/__tests__/HistoryPage_Section_Evolution.test.js
+++ b/src/components/history/__tests__/HistoryPage_Section_Evolution.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 10, 2020
- * Updated  : Aug 18, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react';
@@ -20,11 +20,7 @@ import HistoryPageSectionEvolution from '../HistoryPage_Section_Evolution';
 import { RUN_TEST_NEVER } from '../../../testing/testing'
 
 test('renders HistoryPageSectionEvolution component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(<HistoryPageSectionEvolution config={config}/>);
+  render(<HistoryPageSectionEvolution config={config}/>);
 });
 
 /**

--- a/src/components/history/__tests__/HistoryPage_Section_RangeAndPopulation.test.js
+++ b/src/components/history/__tests__/HistoryPage_Section_RangeAndPopulation.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 10, 2020
- * Updated  : Aug 18, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react';
@@ -20,11 +20,7 @@ import HistoryPageSectionRangeAndPopulation from '../HistoryPage_Section_RangeAn
 import { RUN_TEST_NEVER } from '../../../testing/testing'
 
 test('renders HistoryPageSectionRangeAndPopulation component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(<HistoryPageSectionRangeAndPopulation config={config}/>);
+  render(<HistoryPageSectionRangeAndPopulation config={config}/>);
 });
 
 /**

--- a/src/components/history/__tests__/HistoryPage_Subsection_FelidaeFamilyTree.test.js
+++ b/src/components/history/__tests__/HistoryPage_Subsection_FelidaeFamilyTree.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Aug 17, 2020
- * Updated  : Aug 18, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -20,27 +20,19 @@ import HistoryPageSubsectionFelidaeFamilyTree from '../HistoryPage_Subsection_Fe
 const sectionConfig = config.contentPageSections["section_Evolution"];
 
 test('renders HistoryPageSubsectionFelidaeFamilyTree component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <HistoryPageSubsectionFelidaeFamilyTree
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <HistoryPageSubsectionFelidaeFamilyTree
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 test('HistoryPageSubsectionFelidaeFamilyTree component snapshot', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // const tree = renderer
-  //   .create(
-  //     <HistoryPageSubsectionFelidaeFamilyTree
-  //       sectionConfig={sectionConfig}
-  //     />
-  //   ).toJSON();
-  // expect(tree).toMatchSnapshot();
+  const tree = renderer
+    .create(
+      <HistoryPageSubsectionFelidaeFamilyTree
+        sectionConfig={sectionConfig}
+      />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
 });

--- a/src/components/history/__tests__/HistoryPage_Subsection_RoadToExtinction.test.js
+++ b/src/components/history/__tests__/HistoryPage_Subsection_RoadToExtinction.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Aug 17, 2020
- * Updated  : Aug 18, 2021
+ * Updated  : Aug 21, 2021
  */
 
 import React from 'react'
@@ -22,15 +22,11 @@ import { RUN_TEST_NEVER } from '../../../testing/testing'
 const sectionConfig = config.contentPageSections["section_PopulationAndRange"];
 
 test('renders HistoryPageSubsectionRoadToExtinction component', () => {
-  /**
-   * Disable test because we currently use require.context
-   * and it doesn't work in Jest.
-   */
-  // render(
-  //   <HistoryPageSubsectionRoadToExtinction
-  //     sectionConfig={sectionConfig}
-  //   />
-  // );
+  render(
+    <HistoryPageSubsectionRoadToExtinction
+      sectionConfig={sectionConfig}
+    />
+  );
 });
 
 /**
@@ -38,16 +34,12 @@ test('renders HistoryPageSubsectionRoadToExtinction component', () => {
  */
 RUN_TEST_NEVER(() => {
   test('HistoryPageSubsectionRoadToExtinction component snapshot', () => {
-    /**
-     * Disable test because we currently use require.context
-     * and it doesn't work in Jest.
-     */
-    // const tree = renderer
-    //   .create(
-    //     <HistoryPageSubsectionRoadToExtinction
-    //       sectionConfig={sectionConfig}
-    //     />
-    //   ).toJSON();
-    // expect(tree).toMatchSnapshot();
+    const tree = renderer
+      .create(
+        <HistoryPageSubsectionRoadToExtinction
+          sectionConfig={sectionConfig}
+        />
+      ).toJSON();
+    expect(tree).toMatchSnapshot();
   });
 });

--- a/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_FelidaeFamilyTree.test.js.snap
+++ b/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_FelidaeFamilyTree.test.js.snap
@@ -1,0 +1,2314 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HistoryPageSubsectionFelidaeFamilyTree component snapshot 1`] = `
+<div
+  className="HistoryPageSubsectionFelidaeFamilyTreeOuterContainer"
+>
+  <section
+    className="ContentPageSubsectionTemplateOuterContainer"
+  >
+    <h3
+      className="ContentPageSubsectionTitle"
+    >
+      Evolution of Cats
+    </h3>
+    <div
+      className="HistoryPageSubsectionFelidaeFamilyTreeInnerContainer"
+    >
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Which big cat is the most related to the cheetah?
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          It is easy to think that the closest relative to the cheetah among the big cats is the leopard, given the close resemblance to their appearances. However, the cheetah is actually most closely related to the North American 
+          <b>
+            cougar (puma)
+          </b>
+           (
+          <span
+            className="TaxonomyBinomialName"
+          >
+            Puma concolor
+          </span>
+          ) and the 
+          <b>
+            jaguarundi
+          </b>
+           (
+          <span
+            className="TaxonomyBinomialName"
+          >
+            Herpailurus yagouaroundi
+          </span>
+          ) that roams through Central to South America. Together, these three species form the 
+          <b>
+            <span
+              className="TaxonomyBinomialName"
+            >
+              Puma
+            </span>
+          </b>
+           lineage, one of the eight lineages of the 
+          <span
+            className="TaxonomyBinomialName"
+          >
+            Felidae
+          </span>
+           family.
+        </p>
+        <div
+          className="VerticalCushionPadding"
+        >
+          <img
+            alt="Big Cats"
+            className="FullWidth DisplayBlock RetainAspectRatio Centered"
+            src="Big_Cats_L-min.png"
+          />
+        </div>
+      </div>
+      <div
+        className="ContentPageSubsectionPartContainer"
+      >
+        <h4
+          className="ContentPageSubsectionSubtitle"
+        >
+          Felidae Family Tree
+        </h4>
+        <p
+          className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+        >
+          The evolution of the 
+          <span
+            className="TaxonomyBinomialName"
+          >
+            Felidae
+          </span>
+           cat family began about 25 million years ago. Through time, the ancestors of the cat family slowly evolved into eight main lineages, with each lineage representing a subset of the 
+          <span
+            className="TaxonomyBinomialName"
+          >
+            Felidae
+          </span>
+           cat family that are the most related genetically.
+        </p>
+        <div>
+          <div
+            className="HistoryPageSubsectionFelidaeFamilyTreeCore"
+          >
+            <div
+              className="HintSignpostOuterContainer"
+            >
+              <div
+                className="HintSignpostInnerContainer"
+              >
+                <div
+                  className="ui blue large label"
+                  onClick={[Function]}
+                >
+                  Hover over images below to reveal the members in the Felidae family tree
+                  <div
+                    className="HintSignpostIconContainer"
+                  >
+                    <i
+                      aria-hidden="true"
+                      className="arrow circle down large icon"
+                      onClick={[Function]}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="FelidaeFamilyTreeComponentOuterContainerDiv"
+            >
+              <div
+                style={
+                  Object {
+                    "left": 35,
+                    "position": "absolute",
+                    "top": 10,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_cheetah_Acinonyx_jubatus_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "orange",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Cheetah
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Acinonyx jubatus
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 15,
+                    "position": "absolute",
+                    "top": 160,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_puma_Puma_concolor_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "orange",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Puma
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Puma concolor
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 40,
+                    "position": "absolute",
+                    "top": 310,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_jaguarundi_Herpailurus_yagouaroundi_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "orange",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Jaguarundi
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Herpailurus yagouaroundi
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 180,
+                    "position": "absolute",
+                    "top": 30,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_eurasian_lynx_Lynx_lynx_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(29,88,182",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Eurasian Lynx
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Lynx lynx
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 190,
+                    "position": "absolute",
+                    "top": 190,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_canadian_lynx_Lynx_canadensis_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(29,88,182",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Canadian Lynx
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Lynx canadensis
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 200,
+                    "position": "absolute",
+                    "top": 350,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_iberian_lynx_Lynx_pardinus_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(29,88,182",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Iberian Lynx
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Lynx pardinus
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 180,
+                    "position": "absolute",
+                    "top": 500,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_bobcat_Lynx_rufus_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(29,88,182",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Bobcat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Lynx rufus
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 430,
+                    "position": "absolute",
+                    "top": 20,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_tiger_Panthera_tigris_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(248,180,14)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Tiger
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Panthera tigris
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 580,
+                    "position": "absolute",
+                    "top": 30,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_lion_Panthera_leo_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(248,180,14)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Lion
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Panthera leo
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 400,
+                    "position": "absolute",
+                    "top": 180,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_jaguar_Panthera_onca_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(248,180,14)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Jaguar
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Panthera onca
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 550,
+                    "position": "absolute",
+                    "top": 180,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_leopard_Panthera_pardus_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(248,180,14)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Leopard
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Panthera pardus
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 390,
+                    "position": "absolute",
+                    "top": 330,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_snow_leopard_Panthera_uncia_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(248,180,14)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Snow Leopard
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Panthera uncia
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 330,
+                    "position": "absolute",
+                    "top": 470,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_mainland_clouded_leopard_Neofelis_nebulosa_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(248,180,14)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Mainland Clouded Leopard
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Neofelis nebulosa
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 320,
+                    "position": "absolute",
+                    "top": 620,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_sunda_clouded_leopard_Neofelis_diardi_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(248,180,14)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Sunda Clouded Leopard
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Neofelis diardi
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1340,
+                    "position": "absolute",
+                    "top": 420,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_asiatic_golden_cat_Catopuma_temminckii_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(95,0,221)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Asiatic Golden Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Catopuma temminckii
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1180,
+                    "position": "absolute",
+                    "top": 490,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_borneo_bay_cat_Catopuma_badia_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(95,0,221)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Borneo Bay Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Catopuma badia
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1020,
+                    "position": "absolute",
+                    "top": 540,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_marbled_cat_Pardofelis_marmorata_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(95,0,221)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Marbled Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Pardofelis marmorata
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1400,
+                    "position": "absolute",
+                    "top": 640,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_ocelot_Leopardus_pardalis_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(41,105,3)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Ocelot
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Leopardus pardalis
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1370,
+                    "position": "absolute",
+                    "top": 780,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_geoffroys_cat_Leopardus_geoffroyi_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(41,105,3)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Geoffroy's Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Leopardus geoffroyi
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1200,
+                    "position": "absolute",
+                    "top": 700,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_andean_cat_Leopardus_jacobita_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(41,105,3)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Andean Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Leopardus jacobita
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1020,
+                    "position": "absolute",
+                    "top": 720,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_margay_Leopardus_wiedii_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(41,105,3)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Margay
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Leopardus wiedii
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 880,
+                    "position": "absolute",
+                    "top": 660,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_pampas_cat_Leopardus_colocola_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(41,105,3)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Pampas Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Leopardus colocola
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 730,
+                    "position": "absolute",
+                    "top": 670,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_oncilla_Leopardus_tigrinus_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(41,105,3)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Oncilla - Northern Tiger Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Leopardus tigrinus
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 580,
+                    "position": "absolute",
+                    "top": 730,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_southern_tiger_cat_Leopardus_guttulus_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(41,105,3)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Southern Tiger Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Leopardus guttulus
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1200,
+                    "position": "absolute",
+                    "top": 850,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_guina_Leopardus_guigna_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(41,105,3)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Guiña / Kodkod
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Leopardus guigna
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 790,
+                    "position": "absolute",
+                    "top": 10,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_fishing_cat_Prionailurus_viverrinus_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(232,10,147)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Fishing Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Prionailurus viverrinus
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 750,
+                    "position": "absolute",
+                    "top": 150,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_mainland_leopard_cat_Prionailurus_bengalensis_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(232,10,147)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Mainland Leopard Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Prionailurus bengalensis
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 700,
+                    "position": "absolute",
+                    "top": 300,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_sunda_leopard_cat_Prionailurus_javanensis_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(232,10,147)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Sunda Leopard Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Prionailurus javanensis
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 560,
+                    "position": "absolute",
+                    "top": 400,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_flat_headed_cat_Prionailurus_planiceps_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(232,10,147)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Flat-headed Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Prionailurus planiceps
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 700,
+                    "position": "absolute",
+                    "top": 450,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_rusty_spotted_cat_Prionailurus_rubiginosus_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(232,10,147)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Rusty-spotted Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Prionailurus rubiginosus
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 530,
+                    "position": "absolute",
+                    "top": 560,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_pallas_cat_Otocolobus_manul_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(232,10,147)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Pallas's Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Otocolobus manul
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 950,
+                    "position": "absolute",
+                    "top": 10,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_caracal_Caracal_caracal_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(12,231,168)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Caracal
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Caracal caracal
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 900,
+                    "position": "absolute",
+                    "top": 160,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_serval_Leptailurus_serval_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(12,231,168)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Serval
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Leptailurus serval
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 860,
+                    "position": "absolute",
+                    "top": 300,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_african_golden_cat_Caracal_aurata_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(12,231,168)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        African Golden Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Caracal aurata
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1120,
+                    "position": "absolute",
+                    "top": 30,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_jungle_cat_Felis_chaus_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(154,77,13)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Jungle Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Felis chaus
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1070,
+                    "position": "absolute",
+                    "top": 170,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_chinese_mountain_cat_Felis_bieti_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(154,77,13)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Chinese Mountain Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Felis bieti
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1200,
+                    "position": "absolute",
+                    "top": 170,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_european_wildcat_Felis_silvestris_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(154,77,13)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        European Wildcat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Felis silvestris
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1330,
+                    "position": "absolute",
+                    "top": 230,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_african_wildcat_Felis_lybica_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(154,77,13)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        African-Asiatic Wildcat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Felis lybica
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1200,
+                    "position": "absolute",
+                    "top": 300,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_sand_cat_Felis_margarita_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(154,77,13)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Sand Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Felis margarita
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "left": 1060,
+                    "position": "absolute",
+                    "top": 320,
+                  }
+                }
+              >
+                <div
+                  className="ui fade reveal"
+                  data-testid="TextRevealComponentTestId"
+                >
+                  <div
+                    className="ui visible content"
+                    data-testid="TextRevealComponentVisiblePartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentCoverContainerDiv"
+                    >
+                      <img
+                        className="ui image"
+                        src="felidae_black_footed_cat_Felis_nigripes_240x240-min.jpg"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="ui hidden content"
+                    data-testid="TextRevealComponentHiddenPartTestId"
+                  >
+                    <div
+                      className="TextRevealComponentContentContainerDiv"
+                      style={
+                        Object {
+                          "backgroundColor": "rgb(154,77,13)",
+                        }
+                      }
+                    >
+                      <p
+                        className="TextRevealComponentDescriptionText"
+                        data-testid="TextRevealComponentDescriptionTextPartTestId"
+                      >
+                        Black-footed Cat
+                      </p>
+                      <p
+                        className="TextRevealComponentCaptionText"
+                        data-testid="TextRevealComponentCaptionTextPartTestId"
+                      >
+                        Felis nigripes
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <a
+            href="https://www.wildcatfamily.com/felidae-evolution/"
+          >
+            <button
+              className="ui blue icon button"
+              onClick={[Function]}
+            >
+              Learn more about Felidae Evolution
+              <i
+                aria-hidden="true"
+                className="file alternate outline icon"
+                onClick={[Function]}
+              />
+            </button>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+`;

--- a/src/components/shared/workarounds/RequireContextMock.js
+++ b/src/components/shared/workarounds/RequireContextMock.js
@@ -1,0 +1,65 @@
+/**
+ * RequireContextMock.js
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Aug 21, 2021
+ * Updated  : Aug 21, 2021
+ */
+
+/**
+ * This file consists of a mock version of `require.context` in a function form
+ * that achieves somewhat similar things and is intended to be used in Jest tests
+ * where `require.context` cannot be used.
+ *
+ * Example usage:
+ * 
+ * ```
+ * const context = __TEST__ ? () => (requireContext(__dirname, "./assets/", true)) : () => (require.context("./assets/", true));
+ * const context = requireContextWrapper;
+ * const images = context(__dirname);
+ *
+ * <img src={images("background.png")} />
+ * ```
+ *
+ * More at:
+ * https://stackoverflow.com/questions/38332094/how-can-i-mock-webpacks-require-context-in-jest
+ */
+
+const requireContext = (dirname, base = '.', scanSubDirectories = false, regularExpression = /\.js$/) => {
+  const fs = require('fs');
+  const path = require('path');
+
+  const files = {};
+
+  function readDirectory(directory) {
+    fs.readdirSync(directory).forEach((file) => {
+      const fullPath = path.resolve(directory, file);
+
+      if (fs.statSync(fullPath).isDirectory()) {
+        if (scanSubDirectories) readDirectory(fullPath);
+
+        return;
+      }
+
+      if (!regularExpression.test(fullPath)) return;
+
+      files[fullPath] = true;
+    });
+  }
+
+  readDirectory(path.resolve(dirname, base));
+
+  function Module(file) {
+    // return require(file);
+    return require(path.resolve(dirname, base, file));
+  }
+
+  Module.keys = () => Object.keys(files);
+
+  return Module;
+};
+
+export {
+  requireContext
+}


### PR DESCRIPTION
This patch introduces a workaround for the restricted usage of `require.context` in a Jest setting, by introducing a hand-crafted version of the "function" that mimics the behavior of `require.context` as far as the functionalities required by this project are concerned (i.e. dynamically loading images). In addition, conditionally apply either one of the two based on a predicate determine whether or not the current node environment is a test environment.

The benefit of this patch is that all unit and snapshot tests previously disabled are resurrected.

Updated project version to `0.5.3-alpha.1+08.21.21-1555`