### PR TITLE
Optimize Content Page Intro Image CLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "start": "react-scripts start",
     "test": "react-scripts test --runInBand"
   },
-  "version": "0.5.3-alpha.3+08.22.21-0756"
+  "version": "0.5.3-prealpha.4+08.22.21-0825"
 }

--- a/src/components/biology/config.js
+++ b/src/components/biology/config.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 15, 2020
- * Updated  : Aug 18, 2021
+ * Updated  : Aug 22, 2021
  */
 
 export const config = {
@@ -60,7 +60,11 @@ export const config = {
             "The species name, “IIIjubatusIII”, means “maned”, referring to the mantle on a young cheetah’s back. " +
             "The English word, “cheetah”, comes from the Hindu word “chita” meaning the “spotted one”.",
     image: {
-      filenamePrefix: "Biology_Page_Intro_Section_Background"
+      filenamePrefix: "Biology_Page_Intro_Section_Background",
+      aspectRatio: {
+        width: 720,
+        height: 406
+      }
     }
   },
   contentPageSections: {

--- a/src/components/ecology/config.js
+++ b/src/components/ecology/config.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 19, 2020
- * Updated  : Aug 18, 2021
+ * Updated  : Aug 22, 2021
  */
 
 export const config = {
@@ -57,7 +57,11 @@ export const config = {
             "in educating people to make more sustainable utilizations of the land and its resources, and preserve the richness " +
             "in biodiversity and land fertility for future generations.",
     image: {
-      filenamePrefix: "Ecology_Page_Intro_Section_Background"
+      filenamePrefix: "Ecology_Page_Intro_Section_Background",
+      aspectRatio: {
+        width: 960,
+        height: 640
+      }
     }
   },
   contentPageSections: {

--- a/src/components/future/config.js
+++ b/src/components/future/config.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 14, 2020
- * Updated  : Aug 18, 2021
+ * Updated  : Aug 22, 2021
  */
 
 export const config = {
@@ -54,7 +54,11 @@ export const config = {
             "work together to protect the cheetahs, nurture their ecosystems, and make ourselves better custodians of " +
             "this planet and all living things that share it with us.",
     image: {
-      filenamePrefix: "Future_Page_Intro_Section_Background"
+      filenamePrefix: "Future_Page_Intro_Section_Background",
+      aspectRatio: {
+        width: 640,
+        height: 640
+      }
     }
   },
   contentPageSections: {

--- a/src/components/history/config.js
+++ b/src/components/history/config.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Aug 18, 2021
+ * Updated  : Aug 22, 2021
  */
 
 export const config = {
@@ -60,7 +60,11 @@ export const config = {
           "as a symbol of a multitude of positive characteristics, such as adaptability, " +
           "persistence, and focus.",
     image: {
-      filenamePrefix: "History_Page_Intro_Section_Background"
+      filenamePrefix: "History_Page_Intro_Section_Background",
+      aspectRatio: {
+        width: 861,
+        height: 420
+      }
     }
   },
   contentPageSections: {

--- a/src/components/shared/ContentPageIntroSectionGeneric.css
+++ b/src/components/shared/ContentPageIntroSectionGeneric.css
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 24, 2020
- * Updated  : Aug 12, 2020
+ * Updated  : Aug 22, 2021
  */
 
 div.ContentPageIntroSectionGenericInnerContainer {
@@ -23,6 +23,7 @@ div.ContentPageIntroSectionGenericImgContainer {
 img.ContentPageIntroSectionGenericImg {
   display: block;
   max-width: 100%;
+  height: auto;
   margin: 0 auto;
 }
 
@@ -41,6 +42,7 @@ img.ContentPageIntroSectionGenericImg {
 
   img.ContentPageIntroSectionGenericImg {
     width: 100%;
+    height: auto;
     margin: 0 auto;
   }
 }

--- a/src/components/shared/ContentPageIntroSectionGeneric.js
+++ b/src/components/shared/ContentPageIntroSectionGeneric.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 24, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Aug 22, 2021
  */
 
 import React from 'react'
@@ -63,6 +63,8 @@ export default class ContentPageIntroSectionGeneric extends React.Component {
 
     const coverImageName = GetImagePath("./" + this.props.contentPageIntro.image.filenamePrefix, ".png", matches);
 
+    const aspectRatio =  this.props.contentPageIntro.image.aspectRatio;
+
     return (
       <div className={getElementStyleClassName("ContentPageIntroSectionGenericInnerContainer")}>
         <div className="ContentPageIntroSectionGenericIntroTextContainer">
@@ -75,6 +77,8 @@ export default class ContentPageIntroSectionGeneric extends React.Component {
             className={getElementStyleClassName("ContentPageIntroSectionGenericImg")}
             src={images(coverImageName)}
             alt={this.props.contentPageIntro.title}
+            width={aspectRatio.width}
+            height={aspectRatio.height}
           />
         </div>
       </div>

--- a/src/components/shared/__tests__/ContentPageSkeleton.test.js
+++ b/src/components/shared/__tests__/ContentPageSkeleton.test.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 06, 2020
- * Updated  : Aug 20, 2020
+ * Updated  : Aug 22, 2021
  */
 
 import React from 'react'
@@ -64,7 +64,11 @@ const pageConfig = {
     title: "This is a title",
     content: "This is some content",
     image: {
-      filename: "cheetah-conservation-fund-logo-mini-min.jpg"
+      filenamePrefix: "cheetah-conservation-fund-logo-mini-min",
+      aspectRatio: {
+        width: 410,
+        height: 200
+      }
     }
   }
 };

--- a/src/components/shared/__tests__/__snapshots__/ContentPageSkeleton.test.js.snap
+++ b/src/components/shared/__tests__/__snapshots__/ContentPageSkeleton.test.js.snap
@@ -231,7 +231,9 @@ exports[`ContentPageSkeleton snapshot 1`] = `
                 <img
                   alt="This is a title"
                   className="ContentPageIntroSectionGenericImg"
+                  height={200}
                   src={null}
+                  width={410}
                 />
               </div>
             </div>


### PR DESCRIPTION
This patch attempts the to optimize the Cumulative Layout Shift of the image in the intro section component (i.e. `ContentPageIntroSectionGeneric`) of content pages, based on the guideline specified by https://web.dev/optimize-cls/

Specifically, this is achieved by specifying the aspect ratio of each particular content page's intro section image in the page's corresponding `config.js` file, under the appropriate data member for the intro section image. This way, the flow is data-driven and each particular content page can have an intro section image with a distinct aspect ratio.

Updates project version to `0.5.3-prealpha.4+08.22.21-0825`