### PR TITLE
Introduce `Design2CommonRoundedBorderRadiusStyle` and apply to `ContentPageBanner` component

### DIFF
--- a/src/components/shared/ContentPageBanner.js
+++ b/src/components/shared/ContentPageBanner.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 06, 2020
- * Updated  : Aug 20, 2021
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -12,6 +12,12 @@ import React from 'react'
 import Media from 'react-media'
 
 import { getElementStyleClassNames } from '../../styling/styling'
+
+import {
+  Design2CommonRoundedBorderRadiusStyle
+} from './Design2_CommonUtils'
+
+import { combineStyles } from './Utils'
 
 import { GetImagePath } from '../shared/Path'
 
@@ -53,8 +59,8 @@ export default class ContentPageBanner extends React.Component {
 
     return (
       <div
-        className={getElementStyleClassNames(["ContentPageSkeletonContentContainerDimension",
-                                              "ContentPageBannerContainer"])}
+        className={combineStyles(getElementStyleClassNames(["ContentPageSkeletonContentContainerDimension",
+                                                            "ContentPageBannerContainer"]), Design2CommonRoundedBorderRadiusStyle)}
         style={contentPageBannerContainerStyles}
         data-testid="ContentPageBannerComponentTestId"
         id="ContentPageBanner"

--- a/src/components/shared/Design2.css
+++ b/src/components/shared/Design2.css
@@ -9,6 +9,16 @@
 
 /*******************************************************************************
 
+Shared styles for all components
+
+*******************************************************************************/
+
+.CommonRoundedBorderRadiusStyle {
+  border-radius: 15px;
+}
+
+/*******************************************************************************
+
 Shared styles for Image View like views
 including as `ImageView`, `ImageSlidingGallery`, and `ImageSlidingGalleryDiscrete`
 

--- a/src/components/shared/Design2_CommonUtils.js
+++ b/src/components/shared/Design2_CommonUtils.js
@@ -1,0 +1,20 @@
+/**
+ * Design2_CommonUtils.js
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Jun 09, 2022
+ * Updated  : Jun 09, 2022
+ */
+
+import { join } from './Utils'
+
+const __Design2CommonRoundedBorderRadiusStyle = [
+  "CommonRoundedBorderRadiusStyle"
+]
+
+const Design2CommonRoundedBorderRadiusStyle = join(__Design2CommonRoundedBorderRadiusStyle)
+
+export {
+  Design2CommonRoundedBorderRadiusStyle
+}

--- a/src/components/shared/Design2_ImageViewFamilyUtils.js
+++ b/src/components/shared/Design2_ImageViewFamilyUtils.js
@@ -7,6 +7,8 @@
  * Updated  : Jun 09, 2022
  */
 
+import { join } from './Utils'
+
 const __Design2ImageViewFamilyImgStyles = [
   "ImageViewFamilyImgLayoutStyles",
   "ImageViewFamilyImgBorderStyles"
@@ -22,23 +24,14 @@ const __Design2ImageViewFamilyCaptionContainerStyles = [
   "ImageViewFamilyCaptionContainerStyles"
 ]
 
-function join(arr) {
-  return arr.join(" ")
-}
-
 const Design2ImageViewFamilyImgStyles = join(__Design2ImageViewFamilyImgStyles)
 
 const Design2ImageViewFamilyContainerStyles = join(__Design2ImageViewFamilyContainerStyles)
 
 const Design2ImageViewFamilyCaptionContainerStyles = join(__Design2ImageViewFamilyCaptionContainerStyles)
 
-function combineStyles(a, b) {
-  return (a + " " + b);
-}
-
 export {
   Design2ImageViewFamilyImgStyles,
   Design2ImageViewFamilyContainerStyles,
-  Design2ImageViewFamilyCaptionContainerStyles,
-  combineStyles
+  Design2ImageViewFamilyCaptionContainerStyles
 }

--- a/src/components/shared/ImageSlidingGalleryDiscrete.js
+++ b/src/components/shared/ImageSlidingGalleryDiscrete.js
@@ -32,9 +32,10 @@ import { getFormattedImageCaptionStringWithCredit } from './ImageCaptionUtils'
 import {
   Design2ImageViewFamilyImgStyles,
   Design2ImageViewFamilyContainerStyles,
-  Design2ImageViewFamilyCaptionContainerStyles,
-  combineStyles
+  Design2ImageViewFamilyCaptionContainerStyles
 } from './Design2_ImageViewFamilyUtils'
+
+import { combineStyles } from './Utils'
 
 import {
   getElementStyleClassName,

--- a/src/components/shared/ImageView.js
+++ b/src/components/shared/ImageView.js
@@ -45,9 +45,10 @@ import { getFormattedImageCaptionStringWithCredit}  from './ImageCaptionUtils'
 import {
   Design2ImageViewFamilyImgStyles,
   Design2ImageViewFamilyContainerStyles,
-  Design2ImageViewFamilyCaptionContainerStyles,
-  combineStyles
+  Design2ImageViewFamilyCaptionContainerStyles
 } from './Design2_ImageViewFamilyUtils'
+
+import { combineStyles } from './Utils'
 
 import './ImageView.css'
 

--- a/src/components/shared/Utils.js
+++ b/src/components/shared/Utils.js
@@ -1,0 +1,21 @@
+/**
+ * Utils.js
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Jun 09, 2022
+ * Updated  : Jun 09, 2022
+ */
+
+function join(arr) {
+  return arr.join(" ")
+}
+
+function combineStyles(a, b) {
+  return (a + " " + b);
+}
+
+export {
+  join,
+  combineStyles
+}

--- a/src/components/shared/__tests__/__snapshots__/ContentPageBanner.test.js.snap
+++ b/src/components/shared/__tests__/__snapshots__/ContentPageBanner.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ContentPageBanner component snapshot 1`] = `
 <div
-  className="ContentPageSkeletonContentContainerDimension ContentPageBannerContainer"
+  className="ContentPageSkeletonContentContainerDimension ContentPageBannerContainer CommonRoundedBorderRadiusStyle"
   data-testid="ContentPageBannerComponentTestId"
   id="ContentPageBanner"
   style={

--- a/src/components/shared/__tests__/__snapshots__/ContentPageHead.test.js.snap
+++ b/src/components/shared/__tests__/__snapshots__/ContentPageHead.test.js.snap
@@ -85,7 +85,7 @@ exports[`ContentPageHead component snapshot 1`] = `
       </div>
     </div>
     <div
-      className="ContentPageSkeletonContentContainerDimension ContentPageBannerContainer"
+      className="ContentPageSkeletonContentContainerDimension ContentPageBannerContainer CommonRoundedBorderRadiusStyle"
       data-testid="ContentPageBannerComponentTestId"
       id="ContentPageBanner"
       style={

--- a/src/components/shared/__tests__/__snapshots__/ContentPageSkeleton.test.js.snap
+++ b/src/components/shared/__tests__/__snapshots__/ContentPageSkeleton.test.js.snap
@@ -91,7 +91,7 @@ exports[`ContentPageSkeleton snapshot 1`] = `
           </div>
         </div>
         <div
-          className="ContentPageSkeletonContentContainerDimension ContentPageBannerContainer"
+          className="ContentPageSkeletonContentContainerDimension ContentPageBannerContainer CommonRoundedBorderRadiusStyle"
           data-testid="ContentPageBannerComponentTestId"
           id="ContentPageBanner"
           style={


### PR DESCRIPTION
This patch introduces the style `Design2CommonRoundedBorderRadiusStyle`, and incorporates and applies to the `ContentPageBanner` component.

<img width="1645" alt="Design2_ContentPageBanner" src="https://user-images.githubusercontent.com/554685/172868964-20613c80-faa7-4fb7-b60b-2049216a0dbb.png">

