### PR TITLE
Design 2 - general refinement

### DIFF
--- a/src/components/biology/BiologyPage_Subsection_Abnormalities.js
+++ b/src/components/biology/BiologyPage_Subsection_Abnormalities.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 18, 2020
- * Updated  : Aug 05, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -33,7 +33,8 @@ export default class BiologyPageSubsectionAbnormalities extends React.Component 
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionAbnormalities._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionAbnormalities._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -41,6 +42,7 @@ export default class BiologyPageSubsectionAbnormalities extends React.Component 
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Abnormalities.js
+++ b/src/components/biology/BiologyPage_Subsection_Abnormalities.js
@@ -34,7 +34,7 @@ export default class BiologyPageSubsectionAbnormalities extends React.Component 
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionAbnormalities._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -42,7 +42,7 @@ export default class BiologyPageSubsectionAbnormalities extends React.Component 
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Anatomy.js
+++ b/src/components/biology/BiologyPage_Subsection_Anatomy.js
@@ -33,7 +33,7 @@ export default class BiologyPageSubsectionAnatomy extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionAnatomy._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -41,7 +41,7 @@ export default class BiologyPageSubsectionAnatomy extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/biology/BiologyPage_Subsection_Anatomy.js
+++ b/src/components/biology/BiologyPage_Subsection_Anatomy.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 16, 2020
- * Updated  : Aug 22, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React, { Suspense } from 'react'
@@ -32,7 +32,8 @@ export default class BiologyPageSubsectionAnatomy extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionAnatomy._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionAnatomy._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -40,6 +41,7 @@ export default class BiologyPageSubsectionAnatomy extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/biology/BiologyPage_Subsection_BodyAndBone.js
+++ b/src/components/biology/BiologyPage_Subsection_BodyAndBone.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 16, 2020
- * Updated  : Aug 23, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React, { Suspense } from 'react'
@@ -42,7 +42,8 @@ export default class BiologyPageSubsectionBodyAndBone extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionBodyAndBone._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionBodyAndBone._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -50,6 +51,7 @@ export default class BiologyPageSubsectionBodyAndBone extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_BodyAndBone.js
+++ b/src/components/biology/BiologyPage_Subsection_BodyAndBone.js
@@ -43,7 +43,7 @@ export default class BiologyPageSubsectionBodyAndBone extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionBodyAndBone._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -51,7 +51,7 @@ export default class BiologyPageSubsectionBodyAndBone extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Communication.js
+++ b/src/components/biology/BiologyPage_Subsection_Communication.js
@@ -32,7 +32,7 @@ export default class BiologyPageSubsectionCommunication extends React.Component 
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionCommunication._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -40,7 +40,7 @@ export default class BiologyPageSubsectionCommunication extends React.Component 
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/biology/BiologyPage_Subsection_Communication.js
+++ b/src/components/biology/BiologyPage_Subsection_Communication.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 19, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -31,7 +31,8 @@ export default class BiologyPageSubsectionCommunication extends React.Component 
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionCommunication._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionCommunication._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -39,6 +40,7 @@ export default class BiologyPageSubsectionCommunication extends React.Component 
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
+++ b/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 16, 2020
- * Updated  : Aug 21, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React, { Suspense } from 'react'
@@ -49,7 +49,8 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFeetAndClaws._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFeetAndClaws._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -57,6 +58,7 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
+++ b/src/components/biology/BiologyPage_Subsection_FeetAndClaws.js
@@ -50,7 +50,7 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFeetAndClaws._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -58,7 +58,7 @@ export default class BiologyPageSubsectionFeetAndClaws extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_FindingMate.js
+++ b/src/components/biology/BiologyPage_Subsection_FindingMate.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 17, 2020
- * Updated  : Aug 05, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -29,7 +29,8 @@ export default class BiologyPageSubsectionFindingMate extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFindingMate._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFindingMate._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -37,6 +38,7 @@ export default class BiologyPageSubsectionFindingMate extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_FindingMate.js
+++ b/src/components/biology/BiologyPage_Subsection_FindingMate.js
@@ -30,7 +30,7 @@ export default class BiologyPageSubsectionFindingMate extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionFindingMate._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -38,7 +38,7 @@ export default class BiologyPageSubsectionFindingMate extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_GeneticConfusion.js
+++ b/src/components/biology/BiologyPage_Subsection_GeneticConfusion.js
@@ -28,7 +28,7 @@ export default class BiologyPageSubsectionGeneticConfusion extends React.Compone
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionGeneticConfusion._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -36,7 +36,7 @@ export default class BiologyPageSubsectionGeneticConfusion extends React.Compone
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_GeneticConfusion.js
+++ b/src/components/biology/BiologyPage_Subsection_GeneticConfusion.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 18, 2020
- * Updated  : Jul 29, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -27,7 +27,8 @@ export default class BiologyPageSubsectionGeneticConfusion extends React.Compone
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionGeneticConfusion._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionGeneticConfusion._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -35,6 +36,7 @@ export default class BiologyPageSubsectionGeneticConfusion extends React.Compone
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_HeartAndLung.js
+++ b/src/components/biology/BiologyPage_Subsection_HeartAndLung.js
@@ -37,7 +37,7 @@ export default class BiologyPageSubsectionHearAndLung extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionHearAndLung._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -45,7 +45,7 @@ export default class BiologyPageSubsectionHearAndLung extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/biology/BiologyPage_Subsection_HeartAndLung.js
+++ b/src/components/biology/BiologyPage_Subsection_HeartAndLung.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 16, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React, { Suspense } from 'react'
@@ -36,7 +36,8 @@ export default class BiologyPageSubsectionHearAndLung extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionHearAndLung._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionHearAndLung._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -44,6 +45,7 @@ export default class BiologyPageSubsectionHearAndLung extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/biology/BiologyPage_Subsection_LearningToHunt.js
+++ b/src/components/biology/BiologyPage_Subsection_LearningToHunt.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 18, 2020
- * Updated  : Aug 09, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -31,7 +31,8 @@ export default class BiologyPageSubsectionLearningToHunt extends React.Component
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLearningToHunt._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLearningToHunt._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -39,6 +40,7 @@ export default class BiologyPageSubsectionLearningToHunt extends React.Component
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_LearningToHunt.js
+++ b/src/components/biology/BiologyPage_Subsection_LearningToHunt.js
@@ -32,7 +32,7 @@ export default class BiologyPageSubsectionLearningToHunt extends React.Component
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLearningToHunt._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -40,7 +40,7 @@ export default class BiologyPageSubsectionLearningToHunt extends React.Component
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_1.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_1.js
@@ -30,7 +30,7 @@ export default class BiologyPageSubsectionLifecycleStage1 extends React.Componen
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage1._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -38,7 +38,7 @@ export default class BiologyPageSubsectionLifecycleStage1 extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_1.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_1.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 15, 2020
- * Updated  : Aug 05, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -29,7 +29,8 @@ export default class BiologyPageSubsectionLifecycleStage1 extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage1._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage1._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -37,6 +38,7 @@ export default class BiologyPageSubsectionLifecycleStage1 extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_2.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_2.js
@@ -40,7 +40,7 @@ export default class BiologyPageSubsectionLifecycleStage2 extends React.Componen
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage2._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -48,7 +48,7 @@ export default class BiologyPageSubsectionLifecycleStage2 extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_2.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_2.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 15, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -39,7 +39,8 @@ export default class BiologyPageSubsectionLifecycleStage2 extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage2._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage2._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -47,6 +48,7 @@ export default class BiologyPageSubsectionLifecycleStage2 extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 15, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -36,7 +36,8 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage3._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage3._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -44,6 +45,7 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_3.js
@@ -37,7 +37,7 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage3._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -45,7 +45,7 @@ export default class BiologyPageSubsectionLifecycleStage3 extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_4.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_4.js
@@ -25,7 +25,7 @@ export default class BiologyPageSubsectionLifecycleStage4 extends React.Componen
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage4._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -33,7 +33,7 @@ export default class BiologyPageSubsectionLifecycleStage4 extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_4.js
+++ b/src/components/biology/BiologyPage_Subsection_Lifecycle_Stage_4.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 15, 2020
- * Updated  : Jul 18, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react';
@@ -24,7 +24,8 @@ export default class BiologyPageSubsectionLifecycleStage4 extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage4._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLifecycleStage4._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -32,6 +33,7 @@ export default class BiologyPageSubsectionLifecycleStage4 extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_LivingFastDyingYoung.js
+++ b/src/components/biology/BiologyPage_Subsection_LivingFastDyingYoung.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 17, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -31,7 +31,8 @@ export default class BiologyPageSubsectionLivingFastDyingYoung extends React.Com
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLivingFastDyingYoung._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLivingFastDyingYoung._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -39,6 +40,7 @@ export default class BiologyPageSubsectionLivingFastDyingYoung extends React.Com
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_LivingFastDyingYoung.js
+++ b/src/components/biology/BiologyPage_Subsection_LivingFastDyingYoung.js
@@ -32,7 +32,7 @@ export default class BiologyPageSubsectionLivingFastDyingYoung extends React.Com
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionLivingFastDyingYoung._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -40,7 +40,7 @@ export default class BiologyPageSubsectionLivingFastDyingYoung extends React.Com
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_OpenWide.js
+++ b/src/components/biology/BiologyPage_Subsection_OpenWide.js
@@ -33,7 +33,7 @@ export default class BiologyPageSubsectionOpenWide extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionOpenWide._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -41,7 +41,7 @@ export default class BiologyPageSubsectionOpenWide extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_OpenWide.js
+++ b/src/components/biology/BiologyPage_Subsection_OpenWide.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 16, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -32,7 +32,8 @@ export default class BiologyPageSubsectionOpenWide extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionOpenWide._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionOpenWide._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -40,6 +41,7 @@ export default class BiologyPageSubsectionOpenWide extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_RipAndTear.js
+++ b/src/components/biology/BiologyPage_Subsection_RipAndTear.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 17, 2020
- * Updated  : Aug 05, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -29,7 +29,8 @@ export default class BiologyPageSubsectionRipAndTear extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionRipAndTear._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionRipAndTear._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -37,6 +38,7 @@ export default class BiologyPageSubsectionRipAndTear extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_RipAndTear.js
+++ b/src/components/biology/BiologyPage_Subsection_RipAndTear.js
@@ -30,7 +30,7 @@ export default class BiologyPageSubsectionRipAndTear extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionRipAndTear._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -38,7 +38,7 @@ export default class BiologyPageSubsectionRipAndTear extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Skull.js
+++ b/src/components/biology/BiologyPage_Subsection_Skull.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 16, 2020
- * Updated  : Aug 22, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React, { Suspense } from 'react'
@@ -32,7 +32,8 @@ export default class BiologyPageSubsectionSkull extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSkull._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSkull._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -40,6 +41,7 @@ export default class BiologyPageSubsectionSkull extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_Skull.js
+++ b/src/components/biology/BiologyPage_Subsection_Skull.js
@@ -33,7 +33,7 @@ export default class BiologyPageSubsectionSkull extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSkull._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -41,7 +41,7 @@ export default class BiologyPageSubsectionSkull extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
+++ b/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 17, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React, { Suspense } from 'react'
@@ -49,7 +49,8 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSpotsAndStripes._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSpotsAndStripes._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -57,6 +58,7 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
+++ b/src/components/biology/BiologyPage_Subsection_SpotsAndStripes.js
@@ -50,7 +50,7 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[BiologyPageSubsectionSpotsAndStripes._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -58,7 +58,7 @@ export default class BiologyPageSubsectionSpotsAndStripes extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Section_Genetics.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Section_Genetics.test.js.snap
@@ -16,7 +16,12 @@ exports[`BiologyPageSectionGenetics component snapshot 1`] = `
     Cheetahs exhibit a number of physiological abnormalities because of the genetic bottlenecks that the species have gone through in its history and evolution, with the most recent one being only about 10,000 years ago. Therefore, understanding the genetics of the species is crucial in both saving individuals as well as larger populations.
   </p>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "rgb(240, 240, 240)",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -95,7 +100,12 @@ exports[`BiologyPageSectionGenetics component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "rgb(240, 240, 240)",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Section_Lifecycle.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Section_Lifecycle.test.js.snap
@@ -61,7 +61,12 @@ exports[`BiologyPageSectionLifecyle component snapshot 1`] = `
     />
   </div>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#FFBB00",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -164,7 +169,12 @@ exports[`BiologyPageSectionLifecyle component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#FFBB00",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -222,7 +232,12 @@ exports[`BiologyPageSectionLifecyle component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#FFBB00",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -339,7 +354,12 @@ exports[`BiologyPageSectionLifecyle component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#FFBB00",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -384,7 +404,12 @@ exports[`BiologyPageSectionLifecyle component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#FFBB00",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -410,7 +435,12 @@ exports[`BiologyPageSectionLifecyle component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#FFBB00",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -513,7 +543,12 @@ exports[`BiologyPageSectionLifecyle component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#FFBB00",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Abnormalities.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Abnormalities.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionAbnormalities component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "rgb(240, 240, 240)",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Anatomy.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Anatomy.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionAnatomy component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#98DBC6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Communication.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Communication.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionCommunication component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#98DBC6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_FeetAndClaws.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_FeetAndClaws.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionFeetAndClaws component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#98DBC6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_FindingMate.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_FindingMate.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionFindingMate component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#FFBB00",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_GeneticConfusion.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_GeneticConfusion.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionGeneticConfusion component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "rgb(240, 240, 240)",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_HeartAndLung.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_HeartAndLung.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionHearAndLung component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#98DBC6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_LearningToHunt.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_LearningToHunt.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionLearningToHunt component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#FFBB00",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_1.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_1.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionLifecycleStage1 component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#FFBB00",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_2.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_2.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionLifecycleStage2 component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#FFBB00",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_3.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_3.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionLifecycleStage3 component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#FFBB00",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_4.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_4.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionLifecycleStage4 component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#FFBB00",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_LivingFastDyingYoung.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_LivingFastDyingYoung.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionLivingFastDyingYoung component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#FFBB00",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_OpenWide.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_OpenWide.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionOpenWide component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#98DBC6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_RipAndTear.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_RipAndTear.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPage_Subsection_RipAndTear component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#98DBC6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Skull.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Skull.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionSkull component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#98DBC6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_SpotsAndStripes.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_SpotsAndStripes.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`BiologyPageSubsectionSpotsAndStripes component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#98DBC6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/biology/config.js
+++ b/src/components/biology/config.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 15, 2020
- * Updated  : Aug 25, 2021
+ * Updated  : Jun 10, 2022
  */
 
 export const config = {
@@ -77,6 +77,7 @@ export const config = {
                 "land animal on the planet, nothing speaks more about the incredible adaptations that allow them " +
                 "to survive and thrive in the challenging environments where they live."
       },
+      bgColor: "#FFBB00",
       subsections: {
         subsection_Lifecycle_Stage_1: {
           title: "Stage 1",
@@ -233,6 +234,7 @@ export const config = {
                 "it needs while pursuing a prey. Read on to discover all the fascinating points about the species' " +
                 "anatomy and physiology."
       },
+      bgColor: "#98DBC6",
       subsections: {
         subsection_Anatomy: {
           title: "Anatomy",
@@ -483,6 +485,7 @@ export const config = {
                 "with the most recent one being only about 10,000 years ago. Therefore, understanding the " +
                 "genetics of the species is crucial in both saving individuals as well as larger populations."
       },
+      bgColor: "rgb(240, 240, 240)",
       subsections: {
         subsection_Genetic_Confusion: {
           title: "Genetic Confusion",

--- a/src/components/biology/config.js
+++ b/src/components/biology/config.js
@@ -77,7 +77,7 @@ export const config = {
                 "land animal on the planet, nothing speaks more about the incredible adaptations that allow them " +
                 "to survive and thrive in the challenging environments where they live."
       },
-      bgColor: "#FFBB00",
+      accentColor: "#FFBB00",
       subsections: {
         subsection_Lifecycle_Stage_1: {
           title: "Stage 1",
@@ -234,7 +234,7 @@ export const config = {
                 "it needs while pursuing a prey. Read on to discover all the fascinating points about the species' " +
                 "anatomy and physiology."
       },
-      bgColor: "#98DBC6",
+      accentColor: "#98DBC6",
       subsections: {
         subsection_Anatomy: {
           title: "Anatomy",
@@ -485,7 +485,7 @@ export const config = {
                 "with the most recent one being only about 10,000 years ago. Therefore, understanding the " +
                 "genetics of the species is crucial in both saving individuals as well as larger populations."
       },
-      bgColor: "rgb(240, 240, 240)",
+      accentColor: "rgb(240, 240, 240)",
       subsections: {
         subsection_Genetic_Confusion: {
           title: "Genetic Confusion",

--- a/src/components/ecology/EcologyPage_Subsection_BushEncroachmentAndSolutions.js
+++ b/src/components/ecology/EcologyPage_Subsection_BushEncroachmentAndSolutions.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -42,7 +42,8 @@ export default class EcologyPageSubsectionBushEncroachmentAndSolutions extends R
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionBushEncroachmentAndSolutions._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionBushEncroachmentAndSolutions._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -50,6 +51,7 @@ export default class EcologyPageSubsectionBushEncroachmentAndSolutions extends R
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_BushEncroachmentAndSolutions.js
+++ b/src/components/ecology/EcologyPage_Subsection_BushEncroachmentAndSolutions.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -43,7 +43,7 @@ export default class EcologyPageSubsectionBushEncroachmentAndSolutions extends R
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionBushEncroachmentAndSolutions._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -51,7 +51,7 @@ export default class EcologyPageSubsectionBushEncroachmentAndSolutions extends R
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_CheetahFriendlyFarming.js
+++ b/src/components/ecology/EcologyPage_Subsection_CheetahFriendlyFarming.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 21, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -33,7 +33,7 @@ export default class EcologyPageSubsectionCheetahFriendlyFarming extends React.C
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionCheetahFriendlyFarming._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -41,7 +41,7 @@ export default class EcologyPageSubsectionCheetahFriendlyFarming extends React.C
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_CheetahFriendlyFarming.js
+++ b/src/components/ecology/EcologyPage_Subsection_CheetahFriendlyFarming.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 21, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -32,7 +32,8 @@ export default class EcologyPageSubsectionCheetahFriendlyFarming extends React.C
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionCheetahFriendlyFarming._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionCheetahFriendlyFarming._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -40,6 +41,7 @@ export default class EcologyPageSubsectionCheetahFriendlyFarming extends React.C
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_CheetahsRoleInTheEcosystem.js
+++ b/src/components/ecology/EcologyPage_Subsection_CheetahsRoleInTheEcosystem.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 05, 2020
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -35,7 +35,8 @@ export default class EcologyPageSubsectionCheetahsRoleInTheEcosystem extends Rea
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionCheetahsRoleInTheEcosystem._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionCheetahsRoleInTheEcosystem._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -43,6 +44,7 @@ export default class EcologyPageSubsectionCheetahsRoleInTheEcosystem extends Rea
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_CheetahsRoleInTheEcosystem.js
+++ b/src/components/ecology/EcologyPage_Subsection_CheetahsRoleInTheEcosystem.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -36,7 +36,7 @@ export default class EcologyPageSubsectionCheetahsRoleInTheEcosystem extends Rea
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionCheetahsRoleInTheEcosystem._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -44,7 +44,7 @@ export default class EcologyPageSubsectionCheetahsRoleInTheEcosystem extends Rea
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
+++ b/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -41,7 +41,7 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionHuntingAndPredatorControl._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -49,7 +49,7 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
+++ b/src/components/ecology/EcologyPage_Subsection_HuntingAndPredatorControl.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -40,7 +40,8 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionHuntingAndPredatorControl._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionHuntingAndPredatorControl._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -48,6 +49,7 @@ export default class EcologyPageSubsectionHuntingAndPredatorControl extends Reac
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -41,7 +41,8 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheCheetahsPrey._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheCheetahsPrey._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -49,6 +50,7 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheCheetahsPrey.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -42,7 +42,7 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheCheetahsPrey._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -50,7 +50,7 @@ export default class EcologyPageSubsectionTheCheetahsPrey extends React.Componen
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -41,7 +41,7 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheFarmingCommunity._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -49,7 +49,7 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
+++ b/src/components/ecology/EcologyPage_Subsection_TheFarmingCommunity.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 21, 2021
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -40,7 +40,8 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheFarmingCommunity._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionTheFarmingCommunity._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -48,6 +49,7 @@ export default class EcologyPageSubsectionTheFarmingCommunity extends React.Comp
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_UnderstandingAnimalMovement.js
+++ b/src/components/ecology/EcologyPage_Subsection_UnderstandingAnimalMovement.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 13, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -36,7 +36,8 @@ export default class EcologyPageSubsectionUnderstandingAnimalMovement extends Re
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionUnderstandingAnimalMovement._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionUnderstandingAnimalMovement._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -44,6 +45,7 @@ export default class EcologyPageSubsectionUnderstandingAnimalMovement extends Re
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_UnderstandingAnimalMovement.js
+++ b/src/components/ecology/EcologyPage_Subsection_UnderstandingAnimalMovement.js
@@ -37,7 +37,7 @@ export default class EcologyPageSubsectionUnderstandingAnimalMovement extends Re
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionUnderstandingAnimalMovement._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -45,7 +45,7 @@ export default class EcologyPageSubsectionUnderstandingAnimalMovement extends Re
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
+++ b/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -60,14 +60,17 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionWhereCheetahsLive._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionWhereCheetahsLive._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
   render() {
+    console.log("bg color: " + this.state.bgColor)
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
+++ b/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -61,16 +61,15 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[EcologyPageSubsectionWhereCheetahsLive._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
   render() {
-    console.log("bg color: " + this.state.bgColor)
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_Ecomanagement.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_Ecomanagement.test.js.snap
@@ -16,7 +16,12 @@ exports[`EcologyPageSectionEcomanagement component snapshot 1`] = `
     Effective management of land, livestock, and wildlife are essential ingredients that lead to sustainable utilizations of resources, more sustainable human developments, as well as better conservation of wildlife and the entire ecosystem. Effective farming practices can yield maximal profits and minimal degradations to the land and nature. Conservancies empower farmers with more well-managed ownership of lands, and can generate income through other revenues such as eco-tourism.
   </p>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#C4DFE6",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -183,7 +188,12 @@ exports[`EcologyPageSectionEcomanagement component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#C4DFE6",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -315,7 +325,12 @@ exports[`EcologyPageSectionEcomanagement component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#C4DFE6",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -543,7 +558,12 @@ exports[`EcologyPageSectionEcomanagement component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#C4DFE6",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_EcosystemAndHabitat.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_EcosystemAndHabitat.test.js.snap
@@ -16,7 +16,12 @@ exports[`EcologyPageSectionEcosystemAndHabitat component snapshot 1`] = `
     Understanding the relationships and interactions of elements in the ecosystem and habitat where cheetahs live is crucial for any conservation and management efforts. Understanding of subjects in this area can help answer questions such as “what animals do cheetahs prey on and eat” and “what are its roles in its habitat and relationships with other species of animals”.
   </p>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "rgb(228, 246, 212)",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -384,7 +389,12 @@ exports[`EcologyPageSectionEcosystemAndHabitat component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "rgb(228, 246, 212)",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -609,7 +619,12 @@ exports[`EcologyPageSectionEcosystemAndHabitat component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "rgb(228, 246, 212)",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_Research.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_Research.test.js.snap
@@ -16,7 +16,12 @@ exports[`EcologyPageSectionResearch component snapshot 1`] = `
     Environmental and biological researches provide powerful insights to conservationists in understanding the elements in an ecosystem, as well as answers to questions on how a particular species behave within that system. CCF’s researches provide crucial understanding in cheetah movement, diet, and behavioral patterns in various part of Namibia. These researches help CCF and other conservationists draw crucial decisions on conservation efforts and sustainable developments that benefit both Namibians, livestocks, wildlife, and the land.
   </p>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "rgb(240, 240, 240)",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_BushEncroachmentAndSolutions.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_BushEncroachmentAndSolutions.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`EcologyPageSubsectionBushEncroachmentAndSolutions component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#C4DFE6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_CheetahFriendlyFarming.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_CheetahFriendlyFarming.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`EcologyPageSubsectionCheetahFriendlyFarming component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#C4DFE6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_CheetahsRoleInTheEcosystem.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_CheetahsRoleInTheEcosystem.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`EcologyPageSubsectionCheetahsRoleInTheEcosystem component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "rgb(228, 246, 212)",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_HuntingAndPredatorControl.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_HuntingAndPredatorControl.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`EcologyPageSubsectionHuntingAndPredatorControl component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#C4DFE6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_TheCheetahsPrey.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_TheCheetahsPrey.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`EcologyPageSubsectionTheCheetahsPrey component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "rgb(228, 246, 212)",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_TheFarmingCommunity.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_TheFarmingCommunity.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`EcologyPageSubsectionTheFarmingCommunity component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#C4DFE6",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_UnderstandingAnimalMovement.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_UnderstandingAnimalMovement.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`EcologyPageSubsectionUnderstandingAnimalMovement component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "rgb(240, 240, 240)",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_WhereCheetahsLive.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_WhereCheetahsLive.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`EcologyPageSubsectionWhereCheetahsLive component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "rgb(228, 246, 212)",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/ecology/config.js
+++ b/src/components/ecology/config.js
@@ -74,6 +74,7 @@ export const config = {
                 "“what animals do cheetahs prey on and eat” and “what are its roles in its habitat and " +
                 "relationships with other species of animals”."
       },
+      bgColor: "rgb(228, 246, 212)",
       subsections: {
         subsection_WhereCheetahsLive: {
           title: "Where Cheetahs Live",
@@ -198,6 +199,7 @@ export const config = {
                 "Conservancies empower farmers with more well-managed ownership of lands, and can generate income through other " +
                 "revenues such as eco-tourism."
       },
+      bgColor: "#C4DFE6",
       subsections: {
         subsection_HuntingAndPredatorControl: {
           title: "Hunting and Predator Control",

--- a/src/components/ecology/config.js
+++ b/src/components/ecology/config.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 19, 2020
- * Updated  : Aug 25, 2021
+ * Updated  : Jun 10, 2022
  */
 
 export const config = {
@@ -74,7 +74,7 @@ export const config = {
                 "“what animals do cheetahs prey on and eat” and “what are its roles in its habitat and " +
                 "relationships with other species of animals”."
       },
-      bgColor: "rgb(228, 246, 212)",
+      accentColor: "rgb(228, 246, 212)",
       subsections: {
         subsection_WhereCheetahsLive: {
           title: "Where Cheetahs Live",
@@ -199,7 +199,7 @@ export const config = {
                 "Conservancies empower farmers with more well-managed ownership of lands, and can generate income through other " +
                 "revenues such as eco-tourism."
       },
-      bgColor: "#C4DFE6",
+      accentColor: "#C4DFE6",
       subsections: {
         subsection_HuntingAndPredatorControl: {
           title: "Hunting and Predator Control",
@@ -531,6 +531,7 @@ export const config = {
                 "in cheetah movement, diet, and behavioral patterns in various part of Namibia. These researches help CCF and other conservationists " +
                 "draw crucial decisions on conservation efforts and sustainable developments that benefit both Namibians, livestocks, wildlife, and the land."
       },
+      accentColor: "rgb(240, 240, 240)",
       subsections: {
         subsection_UnderstandingAnimalMovement: {
           title: "Understanding Animal Movement",

--- a/src/components/future/FuturePage_Subsection_CheetahAmbassadors.js
+++ b/src/components/future/FuturePage_Subsection_CheetahAmbassadors.js
@@ -35,7 +35,7 @@ export default class FuturePageSubsectionCheetahAmbassadors extends React.Compon
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCheetahAmbassadors._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -43,7 +43,7 @@ export default class FuturePageSubsectionCheetahAmbassadors extends React.Compon
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/future/FuturePage_Subsection_CheetahAmbassadors.js
+++ b/src/components/future/FuturePage_Subsection_CheetahAmbassadors.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Jun 05, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -34,7 +34,8 @@ export default class FuturePageSubsectionCheetahAmbassadors extends React.Compon
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCheetahAmbassadors._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCheetahAmbassadors._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -42,6 +43,7 @@ export default class FuturePageSubsectionCheetahAmbassadors extends React.Compon
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/future/FuturePage_Subsection_CommunityEvents.js
+++ b/src/components/future/FuturePage_Subsection_CommunityEvents.js
@@ -38,7 +38,7 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCommunityEvents._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -47,7 +47,7 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
       <div>
         <ContentPageSubsectionTemplate
           title={this.state.subsectionConfig.title}
-          bgColor={this.state.bgColor}
+          accentColor={this.state.accentColor}
           content={this.renderContent()}
         />
       </div>

--- a/src/components/future/FuturePage_Subsection_CommunityEvents.js
+++ b/src/components/future/FuturePage_Subsection_CommunityEvents.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -37,7 +37,8 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCommunityEvents._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionCommunityEvents._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -46,6 +47,7 @@ export default class FuturePageSubsectionCommunityEvents extends React.Component
       <div>
         <ContentPageSubsectionTemplate
           title={this.state.subsectionConfig.title}
+          bgColor={this.state.bgColor}
           content={this.renderContent()}
         />
       </div>

--- a/src/components/future/FuturePage_Subsection_FieldResearch.js
+++ b/src/components/future/FuturePage_Subsection_FieldResearch.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Jul 31, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -29,7 +29,8 @@ export default class FuturePageSubsectionFieldResearch extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionFieldResearch._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionFieldResearch._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -37,6 +38,7 @@ export default class FuturePageSubsectionFieldResearch extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_FieldResearch.js
+++ b/src/components/future/FuturePage_Subsection_FieldResearch.js
@@ -30,7 +30,7 @@ export default class FuturePageSubsectionFieldResearch extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionFieldResearch._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -38,7 +38,7 @@ export default class FuturePageSubsectionFieldResearch extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_FutureFarmersOfAfrica.js
+++ b/src/components/future/FuturePage_Subsection_FutureFarmersOfAfrica.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 05, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -31,7 +31,8 @@ export default class FuturePageSubsectionFutureFarmersOfAfrica extends React.Com
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionFutureFarmersOfAfrica._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionFutureFarmersOfAfrica._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -39,6 +40,7 @@ export default class FuturePageSubsectionFutureFarmersOfAfrica extends React.Com
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_FutureFarmersOfAfrica.js
+++ b/src/components/future/FuturePage_Subsection_FutureFarmersOfAfrica.js
@@ -32,7 +32,7 @@ export default class FuturePageSubsectionFutureFarmersOfAfrica extends React.Com
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionFutureFarmersOfAfrica._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -40,7 +40,7 @@ export default class FuturePageSubsectionFutureFarmersOfAfrica extends React.Com
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
+++ b/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -42,7 +42,8 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionInternshipsAndVolunteering._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionInternshipsAndVolunteering._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -50,6 +51,7 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
+++ b/src/components/future/FuturePage_Subsection_InternshipsAndVolunteering.js
@@ -43,7 +43,7 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionInternshipsAndVolunteering._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -51,7 +51,7 @@ export default class FuturePageSubsectionInternshipsAndVolunteering extends Reac
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
+++ b/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
@@ -49,7 +49,7 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionLivestockGuardingDogs._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -57,7 +57,7 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
+++ b/src/components/future/FuturePage_Subsection_LivestockGuardingDogs.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -48,7 +48,8 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionLivestockGuardingDogs._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionLivestockGuardingDogs._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -56,6 +57,7 @@ export default class FuturePageSubsectionLivestockGuardingDogs extends React.Com
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_MissionPossible.js
+++ b/src/components/future/FuturePage_Subsection_MissionPossible.js
@@ -31,7 +31,7 @@ export default class FuturePageSubsectionMissionPossible extends React.Component
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionMissionPossible._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -39,7 +39,7 @@ export default class FuturePageSubsectionMissionPossible extends React.Component
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_MissionPossible.js
+++ b/src/components/future/FuturePage_Subsection_MissionPossible.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -30,7 +30,8 @@ export default class FuturePageSubsectionMissionPossible extends React.Component
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionMissionPossible._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionMissionPossible._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -38,6 +39,7 @@ export default class FuturePageSubsectionMissionPossible extends React.Component
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_SchoolsTeachersLearners.js
+++ b/src/components/future/FuturePage_Subsection_SchoolsTeachersLearners.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -34,7 +34,8 @@ export default class FuturePageSubsectionSchoolsTeachersLearners extends React.C
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionSchoolsTeachersLearners._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionSchoolsTeachersLearners._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -42,6 +43,7 @@ export default class FuturePageSubsectionSchoolsTeachersLearners extends React.C
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_SchoolsTeachersLearners.js
+++ b/src/components/future/FuturePage_Subsection_SchoolsTeachersLearners.js
@@ -35,7 +35,7 @@ export default class FuturePageSubsectionSchoolsTeachersLearners extends React.C
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionSchoolsTeachersLearners._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -43,7 +43,7 @@ export default class FuturePageSubsectionSchoolsTeachersLearners extends React.C
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_StoppingIllegalWildlifeTrades.js
+++ b/src/components/future/FuturePage_Subsection_StoppingIllegalWildlifeTrades.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -54,7 +54,8 @@ export default class FuturePageSubsectionStoppingIllegalWildlifeTrades extends R
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionStoppingIllegalWildlifeTrades._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionStoppingIllegalWildlifeTrades._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -62,6 +63,7 @@ export default class FuturePageSubsectionStoppingIllegalWildlifeTrades extends R
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_StoppingIllegalWildlifeTrades.js
+++ b/src/components/future/FuturePage_Subsection_StoppingIllegalWildlifeTrades.js
@@ -55,7 +55,7 @@ export default class FuturePageSubsectionStoppingIllegalWildlifeTrades extends R
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionStoppingIllegalWildlifeTrades._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -63,7 +63,7 @@ export default class FuturePageSubsectionStoppingIllegalWildlifeTrades extends R
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_TheRoleOfZoos.js
+++ b/src/components/future/FuturePage_Subsection_TheRoleOfZoos.js
@@ -32,7 +32,7 @@ export default class FuturePageSubsectionTheRoleOfZoos extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionTheRoleOfZoos._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -40,7 +40,7 @@ export default class FuturePageSubsectionTheRoleOfZoos extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_TheRoleOfZoos.js
+++ b/src/components/future/FuturePage_Subsection_TheRoleOfZoos.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 05, 2020
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -31,7 +31,8 @@ export default class FuturePageSubsectionTheRoleOfZoos extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionTheRoleOfZoos._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionTheRoleOfZoos._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -39,6 +40,7 @@ export default class FuturePageSubsectionTheRoleOfZoos extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_WhatIsConservation.js
+++ b/src/components/future/FuturePage_Subsection_WhatIsConservation.js
@@ -34,7 +34,7 @@ export default class FuturePageSubsectionWhatIsConservation extends React.Compon
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionWhatIsConservation._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -42,7 +42,7 @@ export default class FuturePageSubsectionWhatIsConservation extends React.Compon
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/FuturePage_Subsection_WhatIsConservation.js
+++ b/src/components/future/FuturePage_Subsection_WhatIsConservation.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 22, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -33,7 +33,8 @@ export default class FuturePageSubsectionWhatIsConservation extends React.Compon
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionWhatIsConservation._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[FuturePageSubsectionWhatIsConservation._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -41,6 +42,7 @@ export default class FuturePageSubsectionWhatIsConservation extends React.Compon
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/future/__tests__/__snapshots__/FuturePageTail.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePageTail.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageTail component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": undefined,
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Section_Conservation.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Section_Conservation.test.js.snap
@@ -16,7 +16,12 @@ exports[`FuturePageSectionConservation component snapshot 1`] = `
     Successful conservation approaches need to be holistic and address the diverse array of inter-related issues, in order to make sure that all parties involved benefit, including the species to be conserved, their ecosystem, and any sustainable utilizations of resources within the ecosystem. Cheetah Conservation Fund develops a set of conservation strategies to ensure that best practices of wildlife and farm management are employed to benefit the cheetahs and their habitats, as well as Namibians who share the same land and resources.
   </p>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#F4EBDB",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -132,7 +137,12 @@ exports[`FuturePageSectionConservation component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#F4EBDB",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -439,7 +449,12 @@ exports[`FuturePageSectionConservation component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#F4EBDB",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Section_OutreachAndEducation.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Section_OutreachAndEducation.test.js.snap
@@ -16,7 +16,12 @@ exports[`FuturePageSectionOutreachAndEducation component snapshot 1`] = `
     Public education is a vital component of any successful conservation strategies. Environmental and management education are critical in areas where people coexist intimately with the land and wildlife. Cheetah Conservation Fund believes public education and outreach will help ensure a future for the species in the wild. CCF educates farmers, teachers, students, and the public about methods to conserve biodiversity, as well as champion the idea that everybody can be a custodian of nature and has something to contribute.
   </p>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#CDFFFF",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -112,7 +117,12 @@ exports[`FuturePageSectionOutreachAndEducation component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#CDFFFF",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -249,7 +259,12 @@ exports[`FuturePageSectionOutreachAndEducation component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#CDFFFF",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -381,7 +396,12 @@ exports[`FuturePageSectionOutreachAndEducation component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#CDFFFF",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -521,7 +541,12 @@ exports[`FuturePageSectionOutreachAndEducation component snapshot 1`] = `
   </section>
   <div>
     <section
-      className="ContentPageSubsectionTemplateOuterContainer"
+      className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+      style={
+        Object {
+          "backgroundColor": "#CDFFFF",
+        }
+      }
     >
       <h3
         className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Section_SustainableDevelopment.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Section_SustainableDevelopment.test.js.snap
@@ -16,7 +16,12 @@ exports[`FuturePageSectionSustainableDevelopment component snapshot 1`] = `
     Sustainable development is key to ensure long term utilizations of natural resources without compromising the integrity of the ecosystem and the sharing of resources by other species. Part of sustainable development involves taking part of the revenue generated from any human development and contribute that to the nurturing and protection of the entire ecosystem. Any human development can be turned to be sustainable by employing the best practices of land, livestock, and wildlife management techniques that have proven to be effective and successful.
   </p>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#F1F0FF",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -130,7 +135,12 @@ exports[`FuturePageSectionSustainableDevelopment component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#F1F0FF",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -308,7 +318,12 @@ exports[`FuturePageSectionSustainableDevelopment component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#F1F0FF",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_CheetahAmbassadors.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_CheetahAmbassadors.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageSubsectionCheetahAmbassadors component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#F4EBDB",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_CommunityEvents.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_CommunityEvents.test.js.snap
@@ -3,7 +3,12 @@
 exports[`FuturePageSubsectionCommunityEvents component snapshot 1`] = `
 <div>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#CDFFFF",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_FieldResearch.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_FieldResearch.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageSubsectionFieldResearch component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#CDFFFF",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_FutureFarmersOfAfrica.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_FutureFarmersOfAfrica.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageSubsectionFutureFarmersOfAfrica component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#F1F0FF",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_InternshipsAndVolunteering.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_InternshipsAndVolunteering.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageSubsectionInternshipsAndVolunteering component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#CDFFFF",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_LivestockGuardingDogs.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_LivestockGuardingDogs.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageSubsectionLivestockGuardingDogs component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#F1F0FF",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_MissionPossible.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_MissionPossible.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageSubsectionMissionPossible component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#F1F0FF",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_SchoolsTeachersLearners.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_SchoolsTeachersLearners.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageSubsectionSchoolsTeachersLearners component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#CDFFFF",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_StoppingIllegalWildlifeTrades.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_StoppingIllegalWildlifeTrades.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageSubsectionStoppingIllegalWildlifeTrades component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#F4EBDB",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_TheRoleOfZoos.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_TheRoleOfZoos.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageSubsectionTheRoleOfZoos component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#CDFFFF",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_WhatIsConservation.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_WhatIsConservation.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`FuturePageSubsectionWhatIsConservation component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#F4EBDB",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/future/config.js
+++ b/src/components/future/config.js
@@ -198,7 +198,7 @@ export const config = {
                 "Any human development can be turned to be sustainable by employing the best practices of land, livestock, and wildlife management " +
                 "techniques that have proven to be effective and successful."
       },
-      bgColor: "#F4EBDB",
+      bgColor: "#F1F0FF",
       subsections: {
         subsection_MissionPossible: {
           title: "Mission Possible",
@@ -347,7 +347,7 @@ export const config = {
                 "CCF educates farmers, teachers, students, and the public about methods to conserve biodiversity, " +
                 "as well as champion the idea that everybody can be a custodian of nature and has something to contribute."
       },
-      bgColor: "#F4EBDB",
+      bgColor: "#CDFFFF",
       subsections: {
         subsection_FieldResearch: {
           title: "Field Research",

--- a/src/components/future/config.js
+++ b/src/components/future/config.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 14, 2020
- * Updated  : Jun 05, 2022
+ * Updated  : Jun 10, 2022
  */
 
 export const config = {
@@ -71,6 +71,7 @@ export const config = {
                 "conservation strategies to ensure that best practices of wildlife and farm management are employed to benefit the " +
                 "cheetahs and their habitats, as well as Namibians who share the same land and resources."
       },
+      bgColor: "#F4EBDB",
       subsections: {
         subsection_WhatIsConservation: {
           title: "What is Conservation?",
@@ -197,6 +198,7 @@ export const config = {
                 "Any human development can be turned to be sustainable by employing the best practices of land, livestock, and wildlife management " +
                 "techniques that have proven to be effective and successful."
       },
+      bgColor: "#F4EBDB",
       subsections: {
         subsection_MissionPossible: {
           title: "Mission Possible",
@@ -345,6 +347,7 @@ export const config = {
                 "CCF educates farmers, teachers, students, and the public about methods to conserve biodiversity, " +
                 "as well as champion the idea that everybody can be a custodian of nature and has something to contribute."
       },
+      bgColor: "#F4EBDB",
       subsections: {
         subsection_FieldResearch: {
           title: "Field Research",

--- a/src/components/future/config.js
+++ b/src/components/future/config.js
@@ -71,7 +71,7 @@ export const config = {
                 "conservation strategies to ensure that best practices of wildlife and farm management are employed to benefit the " +
                 "cheetahs and their habitats, as well as Namibians who share the same land and resources."
       },
-      bgColor: "#F4EBDB",
+      accentColor: "#F4EBDB",
       subsections: {
         subsection_WhatIsConservation: {
           title: "What is Conservation?",
@@ -198,7 +198,7 @@ export const config = {
                 "Any human development can be turned to be sustainable by employing the best practices of land, livestock, and wildlife management " +
                 "techniques that have proven to be effective and successful."
       },
-      bgColor: "#F1F0FF",
+      accentColor: "#F1F0FF",
       subsections: {
         subsection_MissionPossible: {
           title: "Mission Possible",
@@ -347,7 +347,7 @@ export const config = {
                 "CCF educates farmers, teachers, students, and the public about methods to conserve biodiversity, " +
                 "as well as champion the idea that everybody can be a custodian of nature and has something to contribute."
       },
-      bgColor: "#CDFFFF",
+      accentColor: "#CDFFFF",
       subsections: {
         subsection_FieldResearch: {
           title: "Field Research",

--- a/src/components/history/HistoryPage_Subsection_CheetahAndManImage.js
+++ b/src/components/history/HistoryPage_Subsection_CheetahAndManImage.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Aug 23, 2020
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -30,7 +30,8 @@ export default class HistoryPageSubsectionCheetahAndManImage extends React.Compo
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahAndManImage._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahAndManImage._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -38,6 +39,7 @@ export default class HistoryPageSubsectionCheetahAndManImage extends React.Compo
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/history/HistoryPage_Subsection_CheetahAndManImage.js
+++ b/src/components/history/HistoryPage_Subsection_CheetahAndManImage.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -31,7 +31,7 @@ export default class HistoryPageSubsectionCheetahAndManImage extends React.Compo
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahAndManImage._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -39,7 +39,7 @@ export default class HistoryPageSubsectionCheetahAndManImage extends React.Compo
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     )

--- a/src/components/history/HistoryPage_Subsection_Cheetah_Evolution.js
+++ b/src/components/history/HistoryPage_Subsection_Cheetah_Evolution.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 11, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React, { Suspense } from 'react'
@@ -33,7 +33,7 @@ export default class HistoryPageSubsectionCheetahEvolution extends React.Compone
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahEvolution._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -41,7 +41,7 @@ export default class HistoryPageSubsectionCheetahEvolution extends React.Compone
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/history/HistoryPage_Subsection_Cheetah_Evolution.js
+++ b/src/components/history/HistoryPage_Subsection_Cheetah_Evolution.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 11, 2020
- * Updated  : Aug 22, 2020
+ * Updated  : Jun 09, 2022
  */
 
 import React, { Suspense } from 'react'
@@ -32,7 +32,8 @@ export default class HistoryPageSubsectionCheetahEvolution extends React.Compone
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahEvolution._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahEvolution._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -40,6 +41,7 @@ export default class HistoryPageSubsectionCheetahEvolution extends React.Compone
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/history/HistoryPage_Subsection_CheetahsInArt.js
+++ b/src/components/history/HistoryPage_Subsection_CheetahsInArt.js
@@ -29,7 +29,8 @@ export default class HistoryPageSubsectionCheetahsInArt extends React.Component 
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahsInArt._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahsInArt._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -37,6 +38,7 @@ export default class HistoryPageSubsectionCheetahsInArt extends React.Component 
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/history/HistoryPage_Subsection_CheetahsInArt.js
+++ b/src/components/history/HistoryPage_Subsection_CheetahsInArt.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 10, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -30,7 +30,7 @@ export default class HistoryPageSubsectionCheetahsInArt extends React.Component 
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahsInArt._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -38,7 +38,7 @@ export default class HistoryPageSubsectionCheetahsInArt extends React.Component 
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/history/HistoryPage_Subsection_CheetahsInSports.js
+++ b/src/components/history/HistoryPage_Subsection_CheetahsInSports.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 10, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -31,7 +31,7 @@ export default class HistoryPageSubsectionCheetahsInSports extends React.Compone
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahsInSports._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -39,7 +39,7 @@ export default class HistoryPageSubsectionCheetahsInSports extends React.Compone
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/history/HistoryPage_Subsection_CheetahsInSports.js
+++ b/src/components/history/HistoryPage_Subsection_CheetahsInSports.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 10, 2020
- * Updated  : Jun 07, 2022
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -30,7 +30,8 @@ export default class HistoryPageSubsectionCheetahsInSports extends React.Compone
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahsInSports._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionCheetahsInSports._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -38,6 +39,7 @@ export default class HistoryPageSubsectionCheetahsInSports extends React.Compone
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
+++ b/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 09, 2022
  */
 
 import React, { Suspense } from 'react'
@@ -52,7 +52,8 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionFelidaeFamilyTree._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionFelidaeFamilyTree._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -61,6 +62,7 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
       <div className={getElementStyleClassName("HistoryPageSubsectionFelidaeFamilyTreeOuterContainer")}>
         <ContentPageSubsectionTemplate
           title={this.state.subsectionConfig.title}
+          bgColor={this.state.bgColor}
           content={this.renderContent()}
         />
       </div>

--- a/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
+++ b/src/components/history/HistoryPage_Subsection_FelidaeFamilyTree.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React, { Suspense } from 'react'
@@ -53,7 +53,7 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionFelidaeFamilyTree._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -62,7 +62,7 @@ export default class HistoryPageSubsectionFelidaeFamilyTree extends React.Compon
       <div className={getElementStyleClassName("HistoryPageSubsectionFelidaeFamilyTreeOuterContainer")}>
         <ContentPageSubsectionTemplate
           title={this.state.subsectionConfig.title}
-          bgColor={this.state.bgColor}
+          accentColor={this.state.accentColor}
           content={this.renderContent()}
         />
       </div>

--- a/src/components/history/HistoryPage_Subsection_Namibia.js
+++ b/src/components/history/HistoryPage_Subsection_Namibia.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Aug 14, 2020
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -39,7 +39,8 @@ export default class HistoryPageSubsectionNamibia extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionNamibia._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionNamibia._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -47,6 +48,7 @@ export default class HistoryPageSubsectionNamibia extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/history/HistoryPage_Subsection_Namibia.js
+++ b/src/components/history/HistoryPage_Subsection_Namibia.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -40,7 +40,7 @@ export default class HistoryPageSubsectionNamibia extends React.Component {
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionNamibia._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -48,7 +48,7 @@ export default class HistoryPageSubsectionNamibia extends React.Component {
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
+++ b/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 10, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 import React from 'react'
@@ -55,7 +55,7 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
     super(props);
     this.state = {
       subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionRoadToExtinction._SUBSECTION_NAME_],
-      bgColor: props.sectionConfig.bgColor
+      accentColor: props.sectionConfig.accentColor
     };
   }
 
@@ -63,7 +63,7 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
-        bgColor={this.state.bgColor}
+        accentColor={this.state.accentColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
+++ b/src/components/history/HistoryPage_Subsection_RoadToExtinction.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 10, 2020
- * Updated  : Aug 23, 2021
+ * Updated  : Jun 09, 2022
  */
 
 import React from 'react'
@@ -54,7 +54,8 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
   constructor(props) {
     super(props);
     this.state = {
-      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionRoadToExtinction._SUBSECTION_NAME_]
+      subsectionConfig: props.sectionConfig.subsections[HistoryPageSubsectionRoadToExtinction._SUBSECTION_NAME_],
+      bgColor: props.sectionConfig.bgColor
     };
   }
 
@@ -62,6 +63,7 @@ export default class HistoryPageSubsectionRoadToExtinction extends React.Compone
     return (
       <ContentPageSubsectionTemplate
         title={this.state.subsectionConfig.title}
+        bgColor={this.state.bgColor}
         content={this.renderContent()}
       />
     );

--- a/src/components/history/__tests__/__snapshots__/HistoryPage_Section_CheetahAndMan.test.js.snap
+++ b/src/components/history/__tests__/__snapshots__/HistoryPage_Section_CheetahAndMan.test.js.snap
@@ -16,7 +16,12 @@ exports[`HistoryPageSectionCheetahAndMan component snapshot 1`] = `
     The history of cheetah-human relationship goes back in millennia, and archeological artifacts uncovered throughout the world suggest that human interactions with the species goes hand in hand with its migration and evolution. The relationship between cheetahs and us have been both profound and complex, as the species have been revered, utilized, displayed, and exploited throughout human history.
   </p>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#FFF8DC",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -148,7 +153,12 @@ exports[`HistoryPageSectionCheetahAndMan component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#FFF8DC",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"
@@ -285,7 +295,12 @@ exports[`HistoryPageSectionCheetahAndMan component snapshot 1`] = `
     </div>
   </section>
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#FFF8DC",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"

--- a/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_CheetahAndManImage.test.js.snap
+++ b/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_CheetahAndManImage.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`HistoryPageSubsectionCheetahAndManImage component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#FFF8DC",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_CheetahsInArt.test.js.snap
+++ b/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_CheetahsInArt.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`HistoryPageSubsectionCheetahsInArt component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#FFF8DC",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_CheetahsInSports.test.js.snap
+++ b/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_CheetahsInSports.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`HistoryPageSubsectionCheetahsInSports component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "#FFF8DC",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_FelidaeFamilyTree.test.js.snap
+++ b/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_FelidaeFamilyTree.test.js.snap
@@ -5,7 +5,12 @@ exports[`HistoryPageSubsectionFelidaeFamilyTree component snapshot 1`] = `
   className="HistoryPageSubsectionFelidaeFamilyTreeOuterContainer"
 >
   <section
-    className="ContentPageSubsectionTemplateOuterContainer"
+    className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+    style={
+      Object {
+        "backgroundColor": "#rgb(230, 230, 230)",
+      }
+    }
   >
     <h3
       className="ContentPageSubsectionTitle"

--- a/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_Namibia.test.js.snap
+++ b/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_Namibia.test.js.snap
@@ -2,7 +2,12 @@
 
 exports[`HistoryPageSubsectionNamibia component snapshot 1`] = `
 <section
-  className="ContentPageSubsectionTemplateOuterContainer"
+  className="ContentPageSubsectionTemplateOuterContainer CommonRoundedBorderRadiusStyle"
+  style={
+    Object {
+      "backgroundColor": "rgb(216, 216, 216)",
+    }
+  }
 >
   <h3
     className="ContentPageSubsectionTitle"

--- a/src/components/history/config.js
+++ b/src/components/history/config.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 export const config = {
@@ -76,7 +76,7 @@ export const config = {
         "Cheetahs were common throughout Asia, Africa, Europe and North America until the end of the last " +
         "Ice Age, about 10,000 years ago, when massive climatic changes caused large numbers of mammals to disappear."
       },
-      bgColor: "#F18D9E",
+      bgColor: "#rgb(230, 230, 230)",
       subsections: {
         subsection_EvolutionOfCats: {
           title: "Evolution of Cats"
@@ -95,7 +95,7 @@ export const config = {
         "The relationship between cheetahs and us have been both profound and complex, " +
         "as the species have been revered, utilized, displayed, and exploited throughout human history."
       },
-      bgColor: "#F0810F",
+      bgColor: "#FFF8DC",
       subsections: {
         subsection_RelationshipsWithMan: {
           title: "Relationships with Man",

--- a/src/components/history/config.js
+++ b/src/components/history/config.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Aug 25, 2021
+ * Updated  : Jun 09, 2022
  */
 
 export const config = {
@@ -76,6 +76,7 @@ export const config = {
         "Cheetahs were common throughout Asia, Africa, Europe and North America until the end of the last " +
         "Ice Age, about 10,000 years ago, when massive climatic changes caused large numbers of mammals to disappear."
       },
+      bgColor: "#F18D9E",
       subsections: {
         subsection_EvolutionOfCats: {
           title: "Evolution of Cats"
@@ -94,6 +95,7 @@ export const config = {
         "The relationship between cheetahs and us have been both profound and complex, " +
         "as the species have been revered, utilized, displayed, and exploited throughout human history."
       },
+      bgColor: "#F0810F",
       subsections: {
         subsection_RelationshipsWithMan: {
           title: "Relationships with Man",
@@ -178,6 +180,7 @@ export const config = {
                 "southern Africa, spanning over Namibia and Botswana, which together " +
                 "holds two thirds of the species' population."
       },
+      bgColor: "rgb(216, 216, 216)",
       subsections: {
         subsection_Namibia: {
           title: "Namibia - Cheetah Capital of the World",

--- a/src/components/history/config.js
+++ b/src/components/history/config.js
@@ -76,7 +76,7 @@ export const config = {
         "Cheetahs were common throughout Asia, Africa, Europe and North America until the end of the last " +
         "Ice Age, about 10,000 years ago, when massive climatic changes caused large numbers of mammals to disappear."
       },
-      bgColor: "#rgb(230, 230, 230)",
+      accentColor: "#rgb(230, 230, 230)",
       subsections: {
         subsection_EvolutionOfCats: {
           title: "Evolution of Cats"
@@ -95,7 +95,7 @@ export const config = {
         "The relationship between cheetahs and us have been both profound and complex, " +
         "as the species have been revered, utilized, displayed, and exploited throughout human history."
       },
-      bgColor: "#FFF8DC",
+      accentColor: "#FFF8DC",
       subsections: {
         subsection_RelationshipsWithMan: {
           title: "Relationships with Man",
@@ -180,7 +180,7 @@ export const config = {
                 "southern Africa, spanning over Namibia and Botswana, which together " +
                 "holds two thirds of the species' population."
       },
-      bgColor: "rgb(216, 216, 216)",
+      accentColor: "rgb(216, 216, 216)",
       subsections: {
         subsection_Namibia: {
           title: "Namibia - Cheetah Capital of the World",

--- a/src/components/shared/ContentPageSkeleton.css
+++ b/src/components/shared/ContentPageSkeleton.css
@@ -4,11 +4,11 @@
  *
  * Author   : Tomiko
  * Created  : Jul 06, 2020
- * Updated  : Aug 11, 2021
+ * Updated  : Jun 09, 2022
  */
 
 .ContentPageSkeletonOuterContainer {
-  background-color: rgb(239, 239, 239);
+  background-color: rgb(255, 255, 255);
 }
 
 div.ContentPageSkeletonPreContentContainer {
@@ -33,7 +33,7 @@ div.ContentPageSkeletonPreContentContainer {
       the nav bar (e.g. without this the nav bar would appear on top of `ContentPageTableOfContentMenuTemplateCompact`
       on mobile, and since the nav bar has a translucent bg color, it isn't ideal.
   */
-  background-color: rgb(239, 239, 239);
+  background-color: rgb(255, 255, 255);
 }
 
 div.ContentPageSkeletonContentContainer {

--- a/src/components/shared/ContentPageSubsectionTemplate.css
+++ b/src/components/shared/ContentPageSubsectionTemplate.css
@@ -4,14 +4,17 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Aug 18, 2020
+ * Updated  : Jun 09, 2022
  */
 
 .ContentPageSubsectionTemplateOuterContainer {
   margin: 100px auto;
+  background-color: rgb(245, 245, 245);
+  padding: 36px;
 }
 
 h3.ContentPageSubsectionTitle {
+  margin-bottom: 36px; /* NOTE: For asthetics this value matches the padding of `ContentPageSubsectionTemplateOuterContainer` defined above. */
   line-height: 1.4;
   font-family: Arial, Helvetica, sans-serif;
   font-size: 32px;

--- a/src/components/shared/ContentPageSubsectionTemplate.js
+++ b/src/components/shared/ContentPageSubsectionTemplate.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Aug 18, 2020
+ * Updated  : Jun 09, 2022
  */
 
 /**
@@ -21,6 +21,10 @@ import {
   getElementStyleClassName
 } from '../../styling/styling'
 
+import { Design2CommonRoundedBorderRadiusStyle } from '../shared/Design2_CommonUtils'
+
+import { combineStyles } from './Utils'
+
 import './ContentPageSharedStyles.css'
 
 import './ContentPageSubsectionTemplate.css'
@@ -30,7 +34,7 @@ if ( process.env.NODE_ENV === 'development' )
 
 export default function ContentPageSubsectionTemplate(props) {
   return (
-    <section className={getElementStyleClassName("ContentPageSubsectionTemplateOuterContainer")}>
+    <section className={combineStyles(getElementStyleClassName("ContentPageSubsectionTemplateOuterContainer"), Design2CommonRoundedBorderRadiusStyle)}>
       <h3 className={getElementStyleClassName("ContentPageSubsectionTitle")}>
         {props.title}
       </h3>

--- a/src/components/shared/ContentPageSubsectionTemplate.js
+++ b/src/components/shared/ContentPageSubsectionTemplate.js
@@ -33,8 +33,13 @@ if ( process.env.NODE_ENV === 'development' )
   require('./ContentPageSubsectionTemplate-debug.css')
 
 export default function ContentPageSubsectionTemplate(props) {
+
+  const styles = {
+    backgroundColor: props.bgColor
+  }
+
   return (
-    <section className={combineStyles(getElementStyleClassName("ContentPageSubsectionTemplateOuterContainer"), Design2CommonRoundedBorderRadiusStyle)}>
+    <section className={combineStyles(getElementStyleClassName("ContentPageSubsectionTemplateOuterContainer"), Design2CommonRoundedBorderRadiusStyle)} style={styles}>
       <h3 className={getElementStyleClassName("ContentPageSubsectionTitle")}>
         {props.title}
       </h3>

--- a/src/components/shared/ContentPageSubsectionTemplate.js
+++ b/src/components/shared/ContentPageSubsectionTemplate.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 10, 2022
  */
 
 /**
@@ -35,7 +35,7 @@ if ( process.env.NODE_ENV === 'development' )
 export default function ContentPageSubsectionTemplate(props) {
 
   const styles = {
-    backgroundColor: props.bgColor
+    backgroundColor: props.accentColor
   }
 
   return (


### PR DESCRIPTION
This patch introduces a set of large-scale changes to the layout and styles across content pages to refine the aesthetics of content pages. Specifically:

- Refine the background color of `ContentPageSkeleton`.
- Introduces section-specific accent color in a data-driven fashion.
- Introduces padding in `ContentPageSubsectionTemplate` to pad around subsection content.

![Design2_AccentColor](https://user-images.githubusercontent.com/554685/173088899-11424611-12d8-443b-b540-8423285b27d6.png)