### PR TITLE
Introduce Design 2 styles for `MediaLinkButton`

### DIFF
--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Section_Lifecycle.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Section_Lifecycle.test.js.snap
@@ -209,21 +209,20 @@ exports[`BiologyPageSectionLifecyle component snapshot 1`] = `
           <div
             className="ContentPageSubsectionPartContainer"
           >
-            <div>
+            <div
+              className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+            >
               <a
                 href="https://www.youtube.com/embed/Wjtb7XMZlgY"
               >
-                <button
-                  className="ui blue icon button"
-                  onClick={[Function]}
-                >
+                <span>
                   Cheetah Mom Teaches Cubs to Hunt 
-                  <i
-                    aria-hidden="true"
-                    className="youtube icon"
-                    onClick={[Function]}
-                  />
-                </button>
+                </span>
+                <i
+                  aria-hidden="true"
+                  className="youtube icon"
+                  onClick={[Function]}
+                />
               </a>
             </div>
           </div>
@@ -377,21 +376,20 @@ exports[`BiologyPageSectionLifecyle component snapshot 1`] = `
       >
         Cheetahs are diurnal, hunting mornings and early evenings. They rely on their sight to find prey. They spend most of the day resting under shady trees or on termite mounds. Night hunting is only done during a bright moon.
       </p>
-      <div>
+      <div
+        className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+      >
         <a
           href="https://www.nationalgeographic.co.uk/animals/2017/12/stunning-pictures-cheetahs-action"
         >
-          <button
-            className="ui blue icon button"
-            onClick={[Function]}
-          >
+          <span>
             Stunning Pictures of Cheetahs in Action | National Geographic
-            <i
-              aria-hidden="true"
-              className="file image icon"
-              onClick={[Function]}
-            />
-          </button>
+          </span>
+          <i
+            aria-hidden="true"
+            className="file image icon"
+            onClick={[Function]}
+          />
         </a>
       </div>
       <img

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Communication.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Communication.test.js.snap
@@ -144,21 +144,20 @@ exports[`BiologyPageSubsectionCommunication component snapshot 1`] = `
       <div
         className="VerticalCushionPadding"
       >
-        <div>
+        <div
+          className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+        >
           <a
             href="https://www.youtube.com/watch?v=3kFl_TY3iUg"
           >
-            <button
-              className="ui blue icon button"
-              onClick={[Function]}
-            >
+            <span>
               Cheetah Awareness Day - Vocalizations 
-              <i
-                aria-hidden="true"
-                className="youtube icon"
-                onClick={[Function]}
-              />
-            </button>
+            </span>
+            <i
+              aria-hidden="true"
+              className="youtube icon"
+              onClick={[Function]}
+            />
           </a>
         </div>
       </div>

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_2.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_2.test.js.snap
@@ -42,21 +42,20 @@ exports[`BiologyPageSubsectionLifecycleStage2 component snapshot 1`] = `
         <div
           className="ContentPageSubsectionPartContainer"
         >
-          <div>
+          <div
+            className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+          >
             <a
               href="https://www.youtube.com/embed/Wjtb7XMZlgY"
             >
-              <button
-                className="ui blue icon button"
-                onClick={[Function]}
-              >
+              <span>
                 Cheetah Mom Teaches Cubs to Hunt 
-                <i
-                  aria-hidden="true"
-                  className="youtube icon"
-                  onClick={[Function]}
-                />
-              </button>
+              </span>
+              <i
+                aria-hidden="true"
+                className="youtube icon"
+                onClick={[Function]}
+              />
             </a>
           </div>
         </div>

--- a/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_3.test.js.snap
+++ b/src/components/biology/__tests__/__snapshots__/BiologyPage_Subsection_Lifecycle_Stage_3.test.js.snap
@@ -25,21 +25,20 @@ exports[`BiologyPageSubsectionLifecycleStage3 component snapshot 1`] = `
     >
       Cheetahs are diurnal, hunting mornings and early evenings. They rely on their sight to find prey. They spend most of the day resting under shady trees or on termite mounds. Night hunting is only done during a bright moon.
     </p>
-    <div>
+    <div
+      className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+    >
       <a
         href="https://www.nationalgeographic.co.uk/animals/2017/12/stunning-pictures-cheetahs-action"
       >
-        <button
-          className="ui blue icon button"
-          onClick={[Function]}
-        >
+        <span>
           Stunning Pictures of Cheetahs in Action | National Geographic
-          <i
-            aria-hidden="true"
-            className="file image icon"
-            onClick={[Function]}
-          />
-        </button>
+        </span>
+        <i
+          aria-hidden="true"
+          className="file image icon"
+          onClick={[Function]}
+        />
       </a>
     </div>
     <img

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Section_Conservation.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Section_Conservation.test.js.snap
@@ -257,21 +257,20 @@ exports[`FuturePageSectionConservation component snapshot 1`] = `
         <div
           className="VerticalCushionPadding"
         >
-          <div>
+          <div
+            className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+          >
             <a
               href="https://cheetah.org/press-releases/cheetah-conservation-fund-receives-emaciated-cubs-intercepted-from-wildlife-traffickers-by-somaliland-government-in-record-breaking-seizure/"
             >
-              <button
-                className="ui blue icon button"
-                onClick={[Function]}
-              >
+              <span>
                 Read on CCF’s collaboration with the Somaliland government on intercepting cheetah trafficking
-                <i
-                  aria-hidden="true"
-                  className="file alternate outline icon"
-                  onClick={[Function]}
-                />
-              </button>
+              </span>
+              <i
+                aria-hidden="true"
+                className="file alternate outline icon"
+                onClick={[Function]}
+              />
             </a>
           </div>
         </div>
@@ -504,21 +503,20 @@ exports[`FuturePageSectionConservation component snapshot 1`] = `
                     Without farmer support, CCF wouldn't be able to release cheetahs back into the wild. By helping people live alongside predators CCF is helping save the cheetah and its ecosystem.
                   </p>
                   <div>
-                    <div>
+                    <div
+                      className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+                    >
                       <a
                         href="https://www.youtube.com/watch?v=WYjeEG06cjc"
                       >
-                        <button
-                          className="ui blue icon button"
-                          onClick={[Function]}
-                        >
+                        <span>
                           Watch "Walking with Chewbaaka" on YouTube
-                          <i
-                            aria-hidden="true"
-                            className="file video icon"
-                            onClick={[Function]}
-                          />
-                        </button>
+                        </span>
+                        <i
+                          aria-hidden="true"
+                          className="file video icon"
+                          onClick={[Function]}
+                        />
                       </a>
                     </div>
                   </div>

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Section_OutreachAndEducation.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Section_OutreachAndEducation.test.js.snap
@@ -96,21 +96,20 @@ exports[`FuturePageSectionOutreachAndEducation component snapshot 1`] = `
       <div
         className="VerticalCushionPadding"
       >
-        <div>
+        <div
+          className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+        >
           <a
             href="https://cheetah.org/about/what-we-do/research/"
           >
-            <button
-              className="ui blue icon button"
-              onClick={[Function]}
-            >
+            <span>
               Learn more about CCF's research work
-              <i
-                aria-hidden="true"
-                className="file alternate outline icon"
-                onClick={[Function]}
-              />
-            </button>
+            </span>
+            <i
+              aria-hidden="true"
+              className="file alternate outline icon"
+              onClick={[Function]}
+            />
           </a>
         </div>
       </div>
@@ -238,21 +237,20 @@ exports[`FuturePageSectionOutreachAndEducation component snapshot 1`] = `
       <div
         className="ContentPageSubsectionPartContainer"
       >
-        <div>
+        <div
+          className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+        >
           <a
             href="https://cheetah.org/get-involved/volunteer/"
           >
-            <button
-              className="ui blue icon button"
-              onClick={[Function]}
-            >
+            <span>
               Learn more about CCF's Volunteer Program
-              <i
-                aria-hidden="true"
-                className="file alternate outline icon"
-                onClick={[Function]}
-              />
-            </button>
+            </span>
+            <i
+              aria-hidden="true"
+              className="file alternate outline icon"
+              onClick={[Function]}
+            />
           </a>
         </div>
       </div>

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Section_SustainableDevelopment.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Section_SustainableDevelopment.test.js.snap
@@ -296,21 +296,20 @@ exports[`FuturePageSectionSustainableDevelopment component snapshot 1`] = `
         <div
           className="VerticalCushionPadding"
         >
-          <div>
+          <div
+            className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+          >
             <a
               href="https://cheetah.org/canada/about-us/what-we-support/future-farmers-of-africa/"
             >
-              <button
-                className="ui blue icon button"
-                onClick={[Function]}
-              >
+              <span>
                 Read on CCF's blog on Future Farmers of Africa
-                <i
-                  aria-hidden="true"
-                  className="file alternate outline icon"
-                  onClick={[Function]}
-                />
-              </button>
+              </span>
+              <i
+                aria-hidden="true"
+                className="file alternate outline icon"
+                onClick={[Function]}
+              />
             </a>
           </div>
         </div>

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_CheetahAmbassadors.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_CheetahAmbassadors.test.js.snap
@@ -57,21 +57,20 @@ exports[`FuturePageSubsectionCheetahAmbassadors component snapshot 1`] = `
                   Without farmer support, CCF wouldn't be able to release cheetahs back into the wild. By helping people live alongside predators CCF is helping save the cheetah and its ecosystem.
                 </p>
                 <div>
-                  <div>
+                  <div
+                    className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+                  >
                     <a
                       href="https://www.youtube.com/watch?v=WYjeEG06cjc"
                     >
-                      <button
-                        className="ui blue icon button"
-                        onClick={[Function]}
-                      >
+                      <span>
                         Watch "Walking with Chewbaaka" on YouTube
-                        <i
-                          aria-hidden="true"
-                          className="file video icon"
-                          onClick={[Function]}
-                        />
-                      </button>
+                      </span>
+                      <i
+                        aria-hidden="true"
+                        className="file video icon"
+                        onClick={[Function]}
+                      />
                     </a>
                   </div>
                 </div>

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_FieldResearch.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_FieldResearch.test.js.snap
@@ -82,21 +82,20 @@ exports[`FuturePageSubsectionFieldResearch component snapshot 1`] = `
     <div
       className="VerticalCushionPadding"
     >
-      <div>
+      <div
+        className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+      >
         <a
           href="https://cheetah.org/about/what-we-do/research/"
         >
-          <button
-            className="ui blue icon button"
-            onClick={[Function]}
-          >
+          <span>
             Learn more about CCF's research work
-            <i
-              aria-hidden="true"
-              className="file alternate outline icon"
-              onClick={[Function]}
-            />
-          </button>
+          </span>
+          <i
+            aria-hidden="true"
+            className="file alternate outline icon"
+            onClick={[Function]}
+          />
         </a>
       </div>
     </div>

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_FutureFarmersOfAfrica.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_FutureFarmersOfAfrica.test.js.snap
@@ -163,21 +163,20 @@ exports[`FuturePageSubsectionFutureFarmersOfAfrica component snapshot 1`] = `
       <div
         className="VerticalCushionPadding"
       >
-        <div>
+        <div
+          className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+        >
           <a
             href="https://cheetah.org/canada/about-us/what-we-support/future-farmers-of-africa/"
           >
-            <button
-              className="ui blue icon button"
-              onClick={[Function]}
-            >
+            <span>
               Read on CCF's blog on Future Farmers of Africa
-              <i
-                aria-hidden="true"
-                className="file alternate outline icon"
-                onClick={[Function]}
-              />
-            </button>
+            </span>
+            <i
+              aria-hidden="true"
+              className="file alternate outline icon"
+              onClick={[Function]}
+            />
           </a>
         </div>
       </div>

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_InternshipsAndVolunteering.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_InternshipsAndVolunteering.test.js.snap
@@ -123,21 +123,20 @@ exports[`FuturePageSubsectionInternshipsAndVolunteering component snapshot 1`] =
     <div
       className="ContentPageSubsectionPartContainer"
     >
-      <div>
+      <div
+        className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+      >
         <a
           href="https://cheetah.org/get-involved/volunteer/"
         >
-          <button
-            className="ui blue icon button"
-            onClick={[Function]}
-          >
+          <span>
             Learn more about CCF's Volunteer Program
-            <i
-              aria-hidden="true"
-              className="file alternate outline icon"
-              onClick={[Function]}
-            />
-          </button>
+          </span>
+          <i
+            aria-hidden="true"
+            className="file alternate outline icon"
+            onClick={[Function]}
+          />
         </a>
       </div>
     </div>

--- a/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_StoppingIllegalWildlifeTrades.test.js.snap
+++ b/src/components/future/__tests__/__snapshots__/FuturePage_Subsection_StoppingIllegalWildlifeTrades.test.js.snap
@@ -122,21 +122,20 @@ exports[`FuturePageSubsectionStoppingIllegalWildlifeTrades component snapshot 1`
       <div
         className="VerticalCushionPadding"
       >
-        <div>
+        <div
+          className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+        >
           <a
             href="https://cheetah.org/press-releases/cheetah-conservation-fund-receives-emaciated-cubs-intercepted-from-wildlife-traffickers-by-somaliland-government-in-record-breaking-seizure/"
           >
-            <button
-              className="ui blue icon button"
-              onClick={[Function]}
-            >
+            <span>
               Read on CCF’s collaboration with the Somaliland government on intercepting cheetah trafficking
-              <i
-                aria-hidden="true"
-                className="file alternate outline icon"
-                onClick={[Function]}
-              />
-            </button>
+            </span>
+            <i
+              aria-hidden="true"
+              className="file alternate outline icon"
+              onClick={[Function]}
+            />
           </a>
         </div>
       </div>

--- a/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_FelidaeFamilyTree.test.js.snap
+++ b/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_FelidaeFamilyTree.test.js.snap
@@ -2377,21 +2377,20 @@ exports[`HistoryPageSubsectionFelidaeFamilyTree component snapshot 1`] = `
             </div>
           </div>
         </div>
-        <div>
+        <div
+          className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+        >
           <a
             href="https://www.wildcatfamily.com/felidae-evolution/"
           >
-            <button
-              className="ui blue icon button"
-              onClick={[Function]}
-            >
+            <span>
               Learn more about Felidae Evolution
-              <i
-                aria-hidden="true"
-                className="file alternate outline icon"
-                onClick={[Function]}
-              />
-            </button>
+            </span>
+            <i
+              aria-hidden="true"
+              className="file alternate outline icon"
+              onClick={[Function]}
+            />
           </a>
         </div>
       </div>

--- a/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_Namibia.test.js.snap
+++ b/src/components/history/__tests__/__snapshots__/HistoryPage_Subsection_Namibia.test.js.snap
@@ -193,21 +193,20 @@ exports[`HistoryPageSubsectionNamibia component snapshot 1`] = `
     </div>
     <br />
     <br />
-    <div>
+    <div
+      className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+    >
       <a
         href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5729830/"
       >
-        <button
-          className="ui blue icon button"
-          onClick={[Function]}
-        >
+        <span>
           The distribution and numbers of cheetah (Acinonyx jubatus) in southern Africa
-          <i
-            aria-hidden="true"
-            className="file alternate outline icon"
-            onClick={[Function]}
-          />
-        </button>
+        </span>
+        <i
+          aria-hidden="true"
+          className="file alternate outline icon"
+          onClick={[Function]}
+        />
       </a>
     </div>
   </div>

--- a/src/components/shared/Design2.css
+++ b/src/components/shared/Design2.css
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jun 07, 2022
- * Updated  : Jun 07, 2022
+ * Updated  : Jun 11, 2022
  */
 
 /*******************************************************************************
@@ -15,6 +15,10 @@ Shared styles for all components
 
 .CommonRoundedBorderRadiusStyle {
   border-radius: 15px;
+}
+
+.CommonButtonRoundedBorderRadiusStyle {
+  border-radius: 48px;
 }
 
 /*******************************************************************************

--- a/src/components/shared/Design2_CommonUtils.js
+++ b/src/components/shared/Design2_CommonUtils.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jun 09, 2022
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 11, 2022
  */
 
 import { join } from './Utils'
@@ -13,8 +13,15 @@ const __Design2CommonRoundedBorderRadiusStyle = [
   "CommonRoundedBorderRadiusStyle"
 ]
 
+const __Design2CommonButtonRoundedBorderRadiusStyle = [
+  "CommonButtonRoundedBorderRadiusStyle"
+]
+
 const Design2CommonRoundedBorderRadiusStyle = join(__Design2CommonRoundedBorderRadiusStyle)
 
+const Design2CommonButtonRoundedBorderRadiusStyle = join(__Design2CommonButtonRoundedBorderRadiusStyle)
+
 export {
-  Design2CommonRoundedBorderRadiusStyle
+  Design2CommonRoundedBorderRadiusStyle,
+  Design2CommonButtonRoundedBorderRadiusStyle
 }

--- a/src/components/shared/MediaLinkButton.css
+++ b/src/components/shared/MediaLinkButton.css
@@ -1,0 +1,20 @@
+/**
+ * MediaLinkButton.css
+ * Chewbaaka
+ *
+ * Author   : Tomiko
+ * Created  : Jun 11, 2022
+ * Updated  : Jun 11, 2022
+ */
+
+div.MediaLinkButton {
+  display: inline-block;
+  font-weight: bold;
+  padding: 12px;
+  border: 2px solid;
+  box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+}
+
+div.MediaLinkButton a:hover {
+  color: rgb(255,149,0);
+}

--- a/src/components/shared/MediaLinkButton.js
+++ b/src/components/shared/MediaLinkButton.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 07, 2020
- * Updated  : Jul 29, 2020
+ * Updated  : Jun 11, 2022
  */
 
 /**
@@ -27,16 +27,20 @@
 
 import React from 'react'
 
-import { Button, Icon } from 'semantic-ui-react'
+import { Icon } from 'semantic-ui-react'
+ 
+import { Design2CommonButtonRoundedBorderRadiusStyle } from './Design2_CommonUtils';
+
+import { combineStyles } from './Utils';
+
+import './MediaLinkButton.css'
 
 export default function MediaLinkButton(props) {
   return (
-    <div>
+    <div className={combineStyles("MediaLinkButton", Design2CommonButtonRoundedBorderRadiusStyle)}>
       <a href={props.href}>
-        <Button icon color="blue">
-          {props.title}
-          <Icon name={props.icon ? props.icon : "file video"} />
-        </Button>
+        <span>{props.title}</span>
+        <Icon name={props.icon ? props.icon : "file video"} />
       </a>
     </div>
   );

--- a/src/components/shared/__tests__/__snapshots__/MediaLinkButton.test.js.snap
+++ b/src/components/shared/__tests__/__snapshots__/MediaLinkButton.test.js.snap
@@ -1,21 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MediaLinkButton component snapshot 1`] = `
-<div>
+<div
+  className="MediaLinkButton CommonButtonRoundedBorderRadiusStyle"
+>
   <a
     href="https://www.youtube.com/watch?v=WYjeEG06cjc"
   >
-    <button
-      className="ui blue icon button"
-      onClick={[Function]}
-    >
+    <span>
       Watch "Walking with Chewbaaka" on YouTube
-      <i
-        aria-hidden="true"
-        className="file video icon"
-        onClick={[Function]}
-      />
-    </button>
+    </span>
+    <i
+      aria-hidden="true"
+      className="file video icon"
+      onClick={[Function]}
+    />
   </a>
 </div>
 `;


### PR DESCRIPTION
This patch introduces a Design 2 redesign for the component `MediaLinkButton`. This change also reimplements the component to be based on `<div>` and `<a>` tags instead of `Button` from Semantics UI React.

![Design2_MediaLinkButton](https://user-images.githubusercontent.com/554685/173200727-c942c577-e335-45c9-8309-138405ca5e4e.png)
