### PR TITLE
Fix image sliding modal instance dimension overflow issue under Ecology page

### DIFF
--- a/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
+++ b/src/components/ecology/EcologyPage_Subsection_WhereCheetahsLive.js
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 20, 2020
- * Updated  : Jun 10, 2022
+ * Updated  : Jun 11, 2022
  */
 
 import React from 'react'
@@ -14,11 +14,12 @@ import Media from 'react-media'
 import '../shared/ContentPageSharedStyles.css'
 
 import ContentPageSubsectionTemplate from '../shared/ContentPageSubsectionTemplate'
-import ContentPageSubsectionTwoColumnContentTemplate from '../shared/ContentPageSubsectionTwoColumnContentTemplate'
 import ContentPageSubsectionPart from '../shared/ContentPageSubsectionPart'
 import ContentPageParagraph from '../shared/ContentPageParagraph'
 import ContentPageSubsectionSubtitle from '../shared/ContentPageSubsectionSubtitle'
 import ContentPageSideFloatFluidContainer from '../shared/ContentPageSideFloatFluidContainer'
+
+import FluidTwoColumnContainer from '../shared/FluidTwoColumnContainer'
 
 import {
   ContentPageSubsectionParagraphsContentBinder
@@ -182,9 +183,9 @@ export default class EcologyPageSubsectionWhereCheetahsLive extends React.Compon
           {part.title}
         </ContentPageSubsectionSubtitle>
 
-        <ContentPageSubsectionTwoColumnContentTemplate
-          lhsColumn={{content: this.renderPartNamibianBiomesLhs(part)}}
-          rhsColumn={{content: this.renderPartNamibianBiomesRhs(part)}}
+        <FluidTwoColumnContainer
+          lhsColumn={this.renderPartNamibianBiomesLhs(part)}
+          rhsColumn={this.renderPartNamibianBiomesRhs(part)}
         />
 
         <div className="VerticalCushionPaddingTopLarge">

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_EcosystemAndHabitat.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Section_EcosystemAndHabitat.test.js.snap
@@ -135,74 +135,66 @@ exports[`EcologyPageSectionEcosystemAndHabitat component snapshot 1`] = `
           Namibian Biomes
         </h4>
         <div
-          className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+          className="FluidTwoColumnContainerOuterContainer"
         >
           <div
-            className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+            className="FluidTwoColumnContainerColumnContainer FluidTwoColumnLhsContainerColumnContainer"
+          >
+            <p
+              className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+            >
+              Namibia is a country with rich biodiversity, as its land spans over five distinct types of biomes.
+            </p>
+          </div>
+          <div
+            className="FluidTwoColumnContainerColumnContainer FluidTwoColumnRhsContainerColumnContainer"
           >
             <div
-              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer"
+              className="ImageSlideModalCoverTriggerOuterContainer ImageViewFamilyContainerBorderStyles ImageViewFamilyContainerShadowStyles ImageViewFamilyContainerBackgroundStyles"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "width": 480,
+                }
+              }
             >
-              <div>
-                <p
-                  className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
-                >
-                  Namibia is a country with rich biodiversity, as its land spans over five distinct types of biomes.
-                </p>
-              </div>
-            </div>
-            <div
-              className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer"
-            >
-              <div>
-                <div
-                  className="ImageSlideModalCoverTriggerOuterContainer ImageViewFamilyContainerBorderStyles ImageViewFamilyContainerShadowStyles ImageViewFamilyContainerBackgroundStyles"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  style={
-                    Object {
-                      "width": 480,
-                    }
+              <div
+                className="ImageSlideModalCoverTriggerInnerContainer ImageViewFamilyContainerBorderStyles"
+                data-testid="ImageSlideModalComponentCoverImageContainerDivTestId"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "backgroundImage": "url(biome_savanna-min.jpg)",
+                    "height": 320,
+                    "width": 480,
                   }
+                }
+              >
+                <div
+                  className="ImageSlideModalCoverTriggerImageIconInnerContainer"
                 >
-                  <div
-                    className="ImageSlideModalCoverTriggerInnerContainer ImageViewFamilyContainerBorderStyles"
-                    data-testid="ImageSlideModalComponentCoverImageContainerDivTestId"
+                  <i
+                    aria-hidden="true"
+                    className="blue images outline big icon"
                     onClick={[Function]}
-                    style={
-                      Object {
-                        "backgroundImage": "url(biome_savanna-min.jpg)",
-                        "height": 320,
-                        "width": 480,
-                      }
-                    }
-                  >
-                    <div
-                      className="ImageSlideModalCoverTriggerImageIconInnerContainer"
-                    >
-                      <i
-                        aria-hidden="true"
-                        className="blue images outline big icon"
-                        onClick={[Function]}
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className="ImageViewFamilyCaptionContainerStyles"
-                  >
-                    <span>
-                      <i
-                        aria-hidden="true"
-                        className="hand point up outline icon"
-                        onClick={[Function]}
-                      />
-                      Click to learn more about the biomes of Namibia.
-                    </span>
-                  </div>
+                  />
                 </div>
+              </div>
+              <div
+                className="ImageViewFamilyCaptionContainerStyles"
+              >
+                <span>
+                  <i
+                    aria-hidden="true"
+                    className="hand point up outline icon"
+                    onClick={[Function]}
+                  />
+                  Click to learn more about the biomes of Namibia.
+                </span>
               </div>
             </div>
           </div>

--- a/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_WhereCheetahsLive.test.js.snap
+++ b/src/components/ecology/__tests__/__snapshots__/EcologyPage_Subsection_WhereCheetahsLive.test.js.snap
@@ -121,74 +121,66 @@ exports[`EcologyPageSubsectionWhereCheetahsLive component snapshot 1`] = `
         Namibian Biomes
       </h4>
       <div
-        className="ContentPageSubsectionTwoColumnContentTemplateOuterContainer"
+        className="FluidTwoColumnContainerOuterContainer"
       >
         <div
-          className="ContentPageSubsectionTwoColumnContentTemplateInnerContainer"
+          className="FluidTwoColumnContainerColumnContainer FluidTwoColumnLhsContainerColumnContainer"
+        >
+          <p
+            className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
+          >
+            Namibia is a country with rich biodiversity, as its land spans over five distinct types of biomes.
+          </p>
+        </div>
+        <div
+          className="FluidTwoColumnContainerColumnContainer FluidTwoColumnRhsContainerColumnContainer"
         >
           <div
-            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer"
+            className="ImageSlideModalCoverTriggerOuterContainer ImageViewFamilyContainerBorderStyles ImageViewFamilyContainerShadowStyles ImageViewFamilyContainerBackgroundStyles"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={
+              Object {
+                "width": 480,
+              }
+            }
           >
-            <div>
-              <p
-                className="ContentPageRegularTextSize ContentPageRegularTextLineHeight ContentPageContentParagraphText"
-              >
-                Namibia is a country with rich biodiversity, as its land spans over five distinct types of biomes.
-              </p>
-            </div>
-          </div>
-          <div
-            className="ContentPageSubsectionTwoColumnContentTemplateColumnInnerContainer"
-          >
-            <div>
-              <div
-                className="ImageSlideModalCoverTriggerOuterContainer ImageViewFamilyContainerBorderStyles ImageViewFamilyContainerShadowStyles ImageViewFamilyContainerBackgroundStyles"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "width": 480,
-                  }
+            <div
+              className="ImageSlideModalCoverTriggerInnerContainer ImageViewFamilyContainerBorderStyles"
+              data-testid="ImageSlideModalComponentCoverImageContainerDivTestId"
+              onClick={[Function]}
+              style={
+                Object {
+                  "backgroundImage": "url(biome_savanna-min.jpg)",
+                  "height": 320,
+                  "width": 480,
                 }
+              }
+            >
+              <div
+                className="ImageSlideModalCoverTriggerImageIconInnerContainer"
               >
-                <div
-                  className="ImageSlideModalCoverTriggerInnerContainer ImageViewFamilyContainerBorderStyles"
-                  data-testid="ImageSlideModalComponentCoverImageContainerDivTestId"
+                <i
+                  aria-hidden="true"
+                  className="blue images outline big icon"
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "backgroundImage": "url(biome_savanna-min.jpg)",
-                      "height": 320,
-                      "width": 480,
-                    }
-                  }
-                >
-                  <div
-                    className="ImageSlideModalCoverTriggerImageIconInnerContainer"
-                  >
-                    <i
-                      aria-hidden="true"
-                      className="blue images outline big icon"
-                      onClick={[Function]}
-                    />
-                  </div>
-                </div>
-                <div
-                  className="ImageViewFamilyCaptionContainerStyles"
-                >
-                  <span>
-                    <i
-                      aria-hidden="true"
-                      className="hand point up outline icon"
-                      onClick={[Function]}
-                    />
-                    Click to learn more about the biomes of Namibia.
-                  </span>
-                </div>
+                />
               </div>
+            </div>
+            <div
+              className="ImageViewFamilyCaptionContainerStyles"
+            >
+              <span>
+                <i
+                  aria-hidden="true"
+                  className="hand point up outline icon"
+                  onClick={[Function]}
+                />
+                Click to learn more about the biomes of Namibia.
+              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This patch fixes a bug in the Ecology page under the "Where Cheetahs Live" subsection, where the Namibia Biomes `ImageSlidingModal`'s overflows the outer containers when the width of the viewport is less than the width of the sliding modal (i.e. `480px`). This is particularly obvious when viewing on a mobile device with small display size (e.g., iPhone 13 mini).

The underlying cause was that the Namibia Biomes component was nested under `ContentPageSubsectionTwoColumnContentTemplate `, which apparently does not handle child column content dimension overflow very well. The temporary albeit effective solution is to use `FluidTwoColumnContainer` instead.

**Before:**

![ImageSlidingModal_Overflow_Bug_Before](https://user-images.githubusercontent.com/554685/173204314-53c5aab2-b7de-4d64-a1ed-ec6ed0d8b495.png)

**After:**

![ImageSlidingModal_Overflow_Bug_After](https://user-images.githubusercontent.com/554685/173204320-57bc21e8-144c-47d7-a985-6929be4719e3.png)
