### PR TITLE
Introduce Design 2 styles to `ContentPageSideNavMenu` component

### DIFF
--- a/src/components/shared/ContentPageSideNavMenu.css
+++ b/src/components/shared/ContentPageSideNavMenu.css
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 14, 2020
- * Updated  : Aug 05, 2020
+ * Updated  : Jun 13, 2022
  */
 
 div.ContentPageSideNavMenuOuterContainer {
@@ -14,26 +14,35 @@ div.ContentPageSideNavMenuOuterContainer {
   margin-top: 5px;
 }
 
-span.ContentPageSideNavMenuHeader {
-  font-size: 26px;
+div.ui.text.vertical.ContentPageSideNavMenuInnerMenu.menu {
+  padding: 20px;
 }
 
-span.ContentPageSideNavMenuItem {
-  line-height: 1.4em;
-  color: #757575;
-  font-size: 20px;
-  font-weight: bold;
-}
-
-span.ContentPageSideNavMenuItem:hover {
+div.ui.text.vertical.ContentPageSideNavMenuInnerMenu.menu a.active.item :hover {
   color: black;
 }
 
-.ui.text.vertical.menu.ContentPageSideNavMenuInnerMenu a.item {
-  padding-right: 25px;
+span.ContentPageSideNavMenuTopItem {
+  font-size: 26px;
+  color: #757575
 }
 
-.ui.text.vertical.menu.ContentPageSideNavMenuInnerMenu a.item:hover {
+p.ContentPageSideNavMenuTopItemInactive {
+  font-size: 26px;
+  margin: 8px 0px; /* manual fix-up to be consistent with outer menu items */
+}
+
+div.ui.link.list.ContentPageSideNavMenuSectionMenuList {
+  padding-left: 20px;
+  font-size: 16px;
+}
+
+div.ui.link.list.ContentPageSideNavMenuSectionMenuList a.item {
+  padding-right: 32px;
+}
+
+div.ui.link.list.ContentPageSideNavMenuSectionMenuList a.item:hover {
+  color: black;
   background-image: url("./assets/content_page_side_nav_menu_item_background-min.png");
   background-repeat: no-repeat;
   background-position: right center;

--- a/src/components/shared/ContentPageSideNavMenu.js
+++ b/src/components/shared/ContentPageSideNavMenu.js
@@ -4,12 +4,12 @@
  *
  * Author   : Tomiko
  * Created  : Jul 06, 2020
- * Updated  : Aug 18, 2020
+ * Updated  : Jun 13, 2022
  */
 
-import React from 'react'
+import React, { Fragment } from 'react'
 
-import { Menu } from 'semantic-ui-react'
+import { Menu, List } from 'semantic-ui-react'
 
 import { ContentPageSectionTitleToAnchorId } from './ContentPageSectionAnchor'
 
@@ -19,12 +19,17 @@ import 'semantic-ui-css/semantic.min.css'
 
 import './ContentPageSideNavMenu.css'
 
+import { Design2CommonRoundedBorderRadiusStyle } from './Design2_CommonUtils'
+
+import { combineStyles } from './Utils'
+
 export default class ContentPageSideNavMenu extends React.Component {
 
   constructor(props) {
     super(props);
     this.state = {
       // contextRef: props.contextRef,
+      title: props.title,
       items : props.items,
       activeItem : props.items[0]
     }
@@ -39,37 +44,59 @@ export default class ContentPageSideNavMenu extends React.Component {
   }
 
   render() {
-    var menuItems = [];
+    var sectionMenuItems = [];
 
     for (const [idx, item] of this.state.items.entries()) {
-      menuItems.push(
-        <Menu.Item
+      sectionMenuItems.push(
+        <List.Item
           key={idx}
           active={this.state.activeItem === item}
           href={"#"+ContentPageSectionTitleToAnchorId(item)}
           onClick={this.handleItemClick}
         >
-          <span className="ContentPageSideNavMenuItem">
+          <span className="ContentPageSideNavMenuSectionMenuItem">
             {item}
           </span>
-        </Menu.Item>
+        </List.Item>
       );
     }
 
+    const getTopMenuItem = (idx, item) => {
+      if (item === this.props.title) {
+        return (
+          <Fragment key={idx}>
+            <p className="ContentPageSideNavMenuTopItemInactive">
+              {item}
+            </p>
+            <List link className="ContentPageSideNavMenuSectionMenuList">
+              {sectionMenuItems}
+            </List>
+          </Fragment>
+        );
+      } else {
+        return (
+          <Menu.Item
+            key={idx}
+            active={true}
+            href={"/" + (item.toLowerCase() + "/")}
+          >
+            <span className="ContentPageSideNavMenuTopItem">
+              {item}
+            </span>
+          </Menu.Item>
+        );
+      }
+    };
+
+    const contentPageNames = ["History", "Biology", "Ecology", "Future"]
+
     return (
       <div
-        className={getElementStyleClassName("ContentPageSideNavMenuOuterContainer")}
+        className={combineStyles(getElementStyleClassName("ContentPageSideNavMenuOuterContainer"), Design2CommonRoundedBorderRadiusStyle)}
         data-testid="ContentPageSideNavMenuComponentTestId"
       >
         <Menu text vertical className="ContentPageSideNavMenuInnerMenu">
-          <Menu.Item header>
-            <span className="ContentPageSideNavMenuHeader">
-              {this.props.title}
-            </span>
-          </Menu.Item>
-          <nav>
-            {menuItems}
-          </nav>
+          {contentPageNames.map( (item, idx) => getTopMenuItem(idx, item) )}
         </Menu>
       </div>
     );

--- a/src/components/shared/__tests__/__snapshots__/ContentPageSideNavMenu.test.js.snap
+++ b/src/components/shared/__tests__/__snapshots__/ContentPageSideNavMenu.test.js.snap
@@ -2,57 +2,56 @@
 
 exports[`ContentPageSideNavMenu component snapshot 1`] = `
 <div
-  className="ContentPageSideNavMenuOuterContainer"
+  className="ContentPageSideNavMenuOuterContainer CommonRoundedBorderRadiusStyle"
   data-testid="ContentPageSideNavMenuComponentTestId"
 >
   <div
     className="ui text vertical ContentPageSideNavMenuInnerMenu menu"
   >
-    <div
-      className="header item"
+    <a
+      className="active item"
+      href="/history/"
       onClick={[Function]}
     >
       <span
-        className="ContentPageSideNavMenuHeader"
+        className="ContentPageSideNavMenuTopItem"
       >
-        Menu Title
+        History
       </span>
-    </div>
-    <nav>
-      <a
-        className="active item"
-        href="#menuitem1"
-        onClick={[Function]}
+    </a>
+    <a
+      className="active item"
+      href="/biology/"
+      onClick={[Function]}
+    >
+      <span
+        className="ContentPageSideNavMenuTopItem"
       >
-        <span
-          className="ContentPageSideNavMenuItem"
-        >
-          MenuItem1
-        </span>
-      </a>
-      <a
-        className="item"
-        href="#menuitem2"
-        onClick={[Function]}
+        Biology
+      </span>
+    </a>
+    <a
+      className="active item"
+      href="/ecology/"
+      onClick={[Function]}
+    >
+      <span
+        className="ContentPageSideNavMenuTopItem"
       >
-        <span
-          className="ContentPageSideNavMenuItem"
-        >
-          MenuItem2
-        </span>
-      </a>
-      <a
-        className="item"
-        href="#menuitem3"
-        onClick={[Function]}
+        Ecology
+      </span>
+    </a>
+    <a
+      className="active item"
+      href="/future/"
+      onClick={[Function]}
+    >
+      <span
+        className="ContentPageSideNavMenuTopItem"
       >
-        <span
-          className="ContentPageSideNavMenuItem"
-        >
-          MenuItem3
-        </span>
-      </a>
-    </nav>
+        Future
+      </span>
+    </a>
   </div>
 </div>
 `;

--- a/src/components/shared/__tests__/__snapshots__/ContentPageSkeleton.test.js.snap
+++ b/src/components/shared/__tests__/__snapshots__/ContentPageSkeleton.test.js.snap
@@ -631,46 +631,56 @@ exports[`ContentPageSkeleton snapshot 1`] = `
             hidden={true}
           >
             <div
-              className="ContentPageSideNavMenuOuterContainer"
+              className="ContentPageSideNavMenuOuterContainer CommonRoundedBorderRadiusStyle"
               data-testid="ContentPageSideNavMenuComponentTestId"
             >
               <div
                 className="ui text vertical ContentPageSideNavMenuInnerMenu menu"
               >
-                <div
-                  className="header item"
+                <a
+                  className="active item"
+                  href="/history/"
                   onClick={[Function]}
                 >
                   <span
-                    className="ContentPageSideNavMenuHeader"
+                    className="ContentPageSideNavMenuTopItem"
                   >
-                    Title
+                    History
                   </span>
-                </div>
-                <nav>
-                  <a
-                    className="active item"
-                    href="#menu-item-1"
-                    onClick={[Function]}
+                </a>
+                <a
+                  className="active item"
+                  href="/biology/"
+                  onClick={[Function]}
+                >
+                  <span
+                    className="ContentPageSideNavMenuTopItem"
                   >
-                    <span
-                      className="ContentPageSideNavMenuItem"
-                    >
-                      Menu Item 1
-                    </span>
-                  </a>
-                  <a
-                    className="item"
-                    href="#menu-item-2"
-                    onClick={[Function]}
+                    Biology
+                  </span>
+                </a>
+                <a
+                  className="active item"
+                  href="/ecology/"
+                  onClick={[Function]}
+                >
+                  <span
+                    className="ContentPageSideNavMenuTopItem"
                   >
-                    <span
-                      className="ContentPageSideNavMenuItem"
-                    >
-                      Menu Item 2
-                    </span>
-                  </a>
-                </nav>
+                    Ecology
+                  </span>
+                </a>
+                <a
+                  className="active item"
+                  href="/future/"
+                  onClick={[Function]}
+                >
+                  <span
+                    className="ContentPageSideNavMenuTopItem"
+                  >
+                    Future
+                  </span>
+                </a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This patch introduces a refined set of styles to the `ContentPageSideNavMenu` component, with the most significant change to introduce links to content pages, alongside with the existing links that point to sections within the current page.

![Design2_SideNavBar](https://user-images.githubusercontent.com/554685/173727592-f360c63d-ae33-4fcb-9b31-fa9849fd70dd.png)
