### PR TITLE
Fix for Issue #300

### DIFF
--- a/src/components/shared/ContentPageSkeleton.css
+++ b/src/components/shared/ContentPageSkeleton.css
@@ -4,7 +4,7 @@
  *
  * Author   : Tomiko
  * Created  : Jul 06, 2020
- * Updated  : Jun 09, 2022
+ * Updated  : Jun 17, 2022
  */
 
 .ContentPageSkeletonOuterContainer {
@@ -34,6 +34,16 @@ div.ContentPageSkeletonPreContentContainer {
       on mobile, and since the nav bar has a translucent bg color, it isn't ideal.
   */
   background-color: rgb(255, 255, 255);
+}
+
+div.ui.left.internal.rail.ContentPageSkeletonSideRail {
+  /** Specifies the z-index for the side rail nav bar */
+  z-index: 1000;      /** NOTE: Make sure this has a higher value than the z-index value of
+                          `div.ContentPageSkeletonPreContentContainer` defined above.
+
+                          Issue 300 - Content page side nav bar can be clipped by content page banner
+                          https://github.com/tetrachrome/chewbaaka/issues/300
+                      */
 }
 
 div.ContentPageSkeletonContentContainer {


### PR DESCRIPTION
This patch fixes the issue where the content page side nav bar can be clipped by content page banner.

<img width="1914" alt="Fix_Issue_300" src="https://user-images.githubusercontent.com/554685/174420870-6c739a9f-3c7a-452a-b4cd-4a0cfd9c335a.png">
